### PR TITLE
Add '--env' parameter to load a sandboxed environment

### DIFF
--- a/__tests__/all-platforms/esy-bash-tests.js
+++ b/__tests__/all-platforms/esy-bash-tests.js
@@ -36,3 +36,16 @@ it("forwards exit code", async () => {
     const output = await esyBashRun('exit 1')
     expect(output.status).toBe(1)
 })
+
+describe("--env: environment file", async () => {
+    it("loads an environment variable from environment file", () => {
+        const environmentFilePath = path.join(os.tmpdir(), "env-file")
+        const environment = JSON.stringify({
+            "SOME_ENVIRONMENT_VARIABLE": "test-variable-value"
+        })
+
+        const output = await esyBashRun(`--env ${environmentFilePath} echo $SOME_ENVIRONMENT_VARIABLE`)
+
+        expect(out.stdout.indexOf("test-variable-value").toBeGreaterThanOrEqual(0))
+    })
+})

--- a/__tests__/all-platforms/esy-bash-tests.js
+++ b/__tests__/all-platforms/esy-bash-tests.js
@@ -52,6 +52,7 @@ describe("--env: environment file", async () => {
 
         const output = await esyBashRun("echo $SOME_ENVIRONMENT_VARIABLE", environmentFilePath)
 
-        expect(output.stdout.indexOf("test-variable-value").toBeGreaterThanOrEqual(0))
+        expect(output.status).toEqual(0)
+        expect(output.stdout.indexOf("test-variable-value")).toBeGreaterThanOrEqual(0)
     })
 })

--- a/__tests__/all-platforms/esy-bash-tests.js
+++ b/__tests__/all-platforms/esy-bash-tests.js
@@ -8,7 +8,7 @@ const esyBashRun = async (script, envFilePath) => {
 
     const bashPath = path.join(__dirname, "..", "..", "bin", "esy-bash.js")
 
-    const args = env ? [bashPath, "--env", envFilePath, script] : [bashPath, script]
+    const args = envFilePath ? [bashPath, "--env", envFilePath, script] : [bashPath, script]
 
     const output = cp.spawnSync("node", args)
     console.log(` - command returned with status: ${output.status}`)

--- a/__tests__/all-platforms/esy-bash-tests.js
+++ b/__tests__/all-platforms/esy-bash-tests.js
@@ -49,6 +49,6 @@ describe("--env: environment file", async () => {
 
         const output = await esyBashRun(`--env ${environmentFilePath} echo $SOME_ENVIRONMENT_VARIABLE`)
 
-        expect(out.stdout.indexOf("test-variable-value").toBeGreaterThanOrEqual(0))
+        expect(output.stdout.indexOf("test-variable-value").toBeGreaterThanOrEqual(0))
     })
 })

--- a/__tests__/all-platforms/esy-bash-tests.js
+++ b/__tests__/all-platforms/esy-bash-tests.js
@@ -11,6 +11,9 @@ const esyBashRun = async (script) => {
     const output = cp.spawnSync("node", [bashPath, script])
     console.log(` - command returned with status: ${output.status}`)
 
+    console.log(` stdout: ${output.stdout}`)
+    console.log(` stderr: ${output.stderr}`)
+
     return {
         status: output.status,
         stdout: output.stdout.toString("utf8"),

--- a/__tests__/all-platforms/esy-bash-tests.js
+++ b/__tests__/all-platforms/esy-bash-tests.js
@@ -48,6 +48,7 @@ describe("--env: environment file", async () => {
         const environment = JSON.stringify({
             "SOME_ENVIRONMENT_VARIABLE": "test-variable-value"
         })
+        fs.writeFileSync(environmentFilePath, environment)
 
         const output = await esyBashRun("echo $SOME_ENVIRONMENT_VARIABLE", environmentFilePath)
 

--- a/__tests__/all-platforms/esy-bash-tests.js
+++ b/__tests__/all-platforms/esy-bash-tests.js
@@ -3,12 +3,14 @@ const os = require("os")
 const fs = require("fs")
 const path = require("path")
 
-const esyBashRun = async (script) => {
+const esyBashRun = async (script, envFilePath) => {
     console.log(`esy-bash: ${script}`)
 
     const bashPath = path.join(__dirname, "..", "..", "bin", "esy-bash.js")
 
-    const output = cp.spawnSync("node", [bashPath, script])
+    const args = env ? [bashPath, "--env", envFilePath, script] : [bashPath, script]
+
+    const output = cp.spawnSync("node", args)
     console.log(` - command returned with status: ${output.status}`)
 
     console.log(` stdout: ${output.stdout}`)
@@ -47,7 +49,7 @@ describe("--env: environment file", async () => {
             "SOME_ENVIRONMENT_VARIABLE": "test-variable-value"
         })
 
-        const output = await esyBashRun(`--env ${environmentFilePath} echo $SOME_ENVIRONMENT_VARIABLE`)
+        const output = await esyBashRun("echo $SOME_ENVIRONMENT_VARIABLE", environmentFilePath)
 
         expect(output.stdout.indexOf("test-variable-value").toBeGreaterThanOrEqual(0))
     })

--- a/__tests__/all-platforms/esy-bash-tests.js
+++ b/__tests__/all-platforms/esy-bash-tests.js
@@ -38,7 +38,7 @@ it("forwards exit code", async () => {
 })
 
 describe("--env: environment file", async () => {
-    it("loads an environment variable from environment file", () => {
+    it("loads an environment variable from environment file", async () => {
         const environmentFilePath = path.join(os.tmpdir(), "env-file")
         const environment = JSON.stringify({
             "SOME_ENVIRONMENT_VARIABLE": "test-variable-value"

--- a/bash-exec.js
+++ b/bash-exec.js
@@ -16,7 +16,6 @@ let nonce = 0
 const remapPathsInEnvironment = (env) => {
     const val = Object.keys(env).reduce((prev, cur) => {
         const mappedVariable = cur.toLowerCase() === "path" ? process.env["PATH"] + ";" + normalizePath(env[cur]) : normalizePath(env[cur])
-        console.log(`Remapping environment variable [${cur}]: ${env[cur]} -> ${mappedVariable}`)
         return {
             ...prev,
             [cur]: mappedVariable,

--- a/bash-exec.js
+++ b/bash-exec.js
@@ -63,6 +63,8 @@ const bashExec = (bashCommand, options) => {
         const mappedEnvironments = remapPathsInEnvironment(env)
         proc = cygwinExec(normalizedPath, mappedEnvironments)
     } else {
+        // Add executable permission to script file
+        fs.chmodSync(temporaryScriptFile, "755")
         proc = nativeBashExec(normalizedPath, env)
     }
 

--- a/bash-exec.js
+++ b/bash-exec.js
@@ -64,7 +64,7 @@ const bashExec = (bashCommand, options) => {
         proc = cygwinExec(normalizedPath, mappedEnvironments)
     } else {
         // Add executable permission to script file
-        fs.chmodSync(temporaryScriptFile, "755")
+        fs.chmodSync(temporaryScriptFilePath, "755")
         proc = nativeBashExec(normalizedPath, env)
     }
 

--- a/bash-exec.js
+++ b/bash-exec.js
@@ -13,14 +13,40 @@ const normalizePath = (str) => {
 
 let nonce = 0
 
+const remapPathsInEnvironment = (env) => {
+    const val = Object.keys(env).reduce((prev, cur) => {
+        const mappedVariable = cur.toLowerCase() === "path" ? process.env["PATH"] + ";" + normalizePath(env[cur]) : normalizePath(env[cur])
+        console.log(`Remapping environment variable [${cur}]: ${env[cur]} -> ${mappedVariable}`)
+        return {
+            ...prev,
+            [cur]: mappedVariable,
+        }
+    }, {})
+    return val
+}
+
 const bashExec = (bashCommand, options) => {
     options = options || {}
     nonce++
-    console.log("esy-bash: executing bash command: " + bashCommand + `nonce: ${nonce}`)
+    const sanitizedCommand = bashCommand.split("\\").join("/")
+    console.log("esy-bash: executing bash command: " + sanitizedCommand + ` | nonce: ${nonce}`)
+
+    let env = process.env
+
+    if (options.environmentFile) {
+        console.log(" -- using environment file: " + options.environmentFile)
+
+        const envFromFile = JSON.parse(fs.readFileSync(options.environmentFile)) 
+
+        env = {
+            ...env,
+            ...envFromFile,
+        }
+    }
 
     const bashCommandWithDirectoryPreamble = `
         cd ${normalizePath(process.cwd())}
-        ${bashCommand}
+        ${sanitizedCommand}
     `
     const command = normalizeEndlines(bashCommandWithDirectoryPreamble)
 
@@ -29,13 +55,15 @@ const bashExec = (bashCommand, options) => {
 
     fs.writeFileSync(temporaryScriptFilePath, bashCommandWithDirectoryPreamble, "utf8")
     let normalizedPath = normalizePath(temporaryScriptFilePath)
+    console.log(" -- script file: " + normalizedPath)
 
     let proc = null
 
     if (os.platform() === "win32") {
-        proc = cygwinExec(normalizedPath, options)
+        const mappedEnvironments = remapPathsInEnvironment(env)
+        proc = cygwinExec(normalizedPath, mappedEnvironments)
     } else {
-        proc = nativeBashExec(normalizedPath, options)
+        proc = nativeBashExec(normalizedPath, env)
     }
 
     return new Promise((res, rej) => {
@@ -46,29 +74,26 @@ const bashExec = (bashCommand, options) => {
     })
 }
 
-const nativeBashExec = (bashCommandFilePath, options) => {
+const nativeBashExec = (bashCommandFilePath, env) => {
     return cp.spawn("bash", ["-c", bashCommandFilePath], {
         stdio: "inherit",
         cwd: process.cwd(),
-        ...options,
+        env: env,
     })
 }
 
 
-const cygwinExec = (bashCommandFilePath, options) => {
+const cygwinExec = (bashCommandFilePath, env) => {
 
     // Create a temporary shell script to run the command,
     // since the process doesn't respect `cwd`.
 
     const bashArguments = bashCommandFilePath ? "-lc" : "-l"
 
-    return cp.spawn(bashPath, [bashArguments, bashCommandFilePath], {
+    return cp.spawn(bashPath, [bashArguments, ". " + bashCommandFilePath], {
         stdio: "inherit",
         cwd: process.cwd(),
-        env: {
-            ...process.env,
-        },
-        ...options,
+        env: env,
     })
 }
 

--- a/bin/esy-bash.js
+++ b/bin/esy-bash.js
@@ -3,8 +3,18 @@
 "use strict"
 
 const { bashExec } = require("./../index")
-const args = process.argv.slice(2).join(" ")
 
-bashExec(args).then((code) => {
+let opts = null
+
+if (process.argv.length >= 3 && process.argv[2] === "--env") {
+    opts = {
+        environmentFile: process.argv[3]
+    }
+}
+
+const args = opts ? process.argv.slice(4).join(" ") : process.argv.slice(2).join(" ")
+console.log(args)
+
+bashExec(args, opts).then((code) => {
     process.exit(code)
 })


### PR DESCRIPTION
This change adds an `--env` parameter which allows for specifying the set of environment variables, in order to run the bash script in a semi-sandboxed environment.