### PR TITLE
Add utility to resolve Windows path -> cygwin path

### DIFF
--- a/__tests__/windows/toCygwinPath-tests.js
+++ b/__tests__/windows/toCygwinPath-tests.js
@@ -4,7 +4,7 @@ const { toCygwinPath } = require("./../../index")
 
 describe("toCygwinPath", () => {
     it("resolves simple path correctly", () => {
-        const resolvedPath = toCygPath("C:\\test")
+        const resolvedPath = toCygwinPath("C:\\test")
         expect(resolvedPath).toBe("/cygdrive/c/test")
     })
 })

--- a/__tests__/windows/toCygwinPath-tests.js
+++ b/__tests__/windows/toCygwinPath-tests.js
@@ -1,0 +1,11 @@
+const os = require("os")
+
+const { toCygwinPath } = require("./../../index")
+
+describe("toCygwinPath", () => {
+    it("resolves simple path correctly", () => {
+        const resolvedPath = toCygPath("C:\\test")
+        expect(resolvedPath).toBe("/cygdrive/c/test")
+    })
+})
+

--- a/bash-exec.js
+++ b/bash-exec.js
@@ -54,6 +54,15 @@ const nativeBashExec = (bashCommandFilePath, options) => {
     })
 }
 
+const toCygwinPath = (originalPath) => {
+    if (os.platform() !== "win32") {
+        return originalPath
+    }
+
+    const normalizedPath = normalizePath(windowsPath)
+
+    return cp.spawnSync(bashPath, ["-lc", "cygpath", normalizedPath]).stdout.toString("utf8")
+}
 
 const cygwinExec = (bashCommandFilePath, options) => {
 
@@ -74,5 +83,6 @@ const cygwinExec = (bashCommandFilePath, options) => {
 
 module.exports = {
     bashExec,
+    toCyginPath,
 }
 

--- a/bash-exec.js
+++ b/bash-exec.js
@@ -59,9 +59,11 @@ const toCygwinPath = (originalPath) => {
         return originalPath
     }
 
-    const normalizedPath = normalizePath(windowsPath)
+    const normalizedPath = normalizePath(originalPath)
 
-    return cp.spawnSync(bashPath, ["-lc", "cygpath", normalizedPath]).stdout.toString("utf8")
+    const ret = cp.spawnSync(bashPath, ["-lc", `cygpath ${normalizedPath}`])
+    let val = ret.stdout.toString("utf8")
+    return val ? val.trim() : null
 }
 
 const cygwinExec = (bashCommandFilePath, options) => {
@@ -83,6 +85,6 @@ const cygwinExec = (bashCommandFilePath, options) => {
 
 module.exports = {
     bashExec,
-    toCyginPath,
+    toCygwinPath,
 }
 

--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
-const { bashExec } = require("./bash-exec")
+const { bashExec, toCygwinPath } = require("./bash-exec")
 
 module.exports = {
     bashExec,
+    toCygwinPath,
 }


### PR DESCRIPTION
This adds a `toCygwinPath` API, that converts a Windows path to a cygwin path (ie, "C:\\temp" -> "/cygdrive/c/temp"). On other platforms, it's a no-op.