### PR TITLE
Only remap with specified environment file

### DIFF
--- a/bash-exec.js
+++ b/bash-exec.js
@@ -36,11 +36,12 @@ const bashExec = (bashCommand, options) => {
         console.log(" -- using environment file: " + options.environmentFile)
 
         const envFromFile = JSON.parse(fs.readFileSync(options.environmentFile)) 
+        cosnt remappedPaths = remapPathsInEnvironment(envFromFile)
 
-        env = remapPathsInEnvironment({
+        env = {
             ...env,
-            ...envFromFile,
-        })
+            ...remappedPaths,
+        }
     }
 
     const bashCommandWithDirectoryPreamble = `

--- a/bash-exec.js
+++ b/bash-exec.js
@@ -35,8 +35,8 @@ const bashExec = (bashCommand, options) => {
     if (options.environmentFile) {
         console.log(" -- using environment file: " + options.environmentFile)
 
-        const envFromFile = JSON.parse(fs.readFileSync(options.environmentFile)) 
-        cosnt remappedPaths = remapPathsInEnvironment(envFromFile)
+        const envFromFile = JSON.parse(fs.readFileSync(options.environmentFile))
+        const remappedPaths = remapPathsInEnvironment(envFromFile)
 
         env = {
             ...env,

--- a/bash-exec.js
+++ b/bash-exec.js
@@ -37,10 +37,10 @@ const bashExec = (bashCommand, options) => {
 
         const envFromFile = JSON.parse(fs.readFileSync(options.environmentFile)) 
 
-        env = {
+        env = remapPathsInEnvironment({
             ...env,
             ...envFromFile,
-        }
+        })
     }
 
     const bashCommandWithDirectoryPreamble = `
@@ -59,8 +59,7 @@ const bashExec = (bashCommand, options) => {
     let proc = null
 
     if (os.platform() === "win32") {
-        const mappedEnvironments = remapPathsInEnvironment(env)
-        proc = cygwinExec(normalizedPath, mappedEnvironments)
+        proc = cygwinExec(normalizedPath, env)
     } else {
         // Add executable permission to script file
         fs.chmodSync(temporaryScriptFilePath, "755")


### PR DESCRIPTION
__Issue:__ When there is no environment path specified, the `PATH` would be double-added, causing issues.

__Fix:__ Only call remap with environment file.