### PR TITLE
Fix issue where args array is not handled properly

### DIFF
--- a/__tests__/all-platforms/esy-bash-tests.js
+++ b/__tests__/all-platforms/esy-bash-tests.js
@@ -5,10 +5,11 @@ const path = require("path")
 
 const { bashExec } = require("./../../index")
 
+
+const bashPath = path.join(__dirname, "..", "..", "bin", "esy-bash.js")
+
 const esyBashRun = async (script, envFilePath) => {
     console.log(`esy-bash: ${script}`)
-
-    const bashPath = path.join(__dirname, "..", "..", "bin", "esy-bash.js")
 
     const args = envFilePath ? [bashPath, "--env", envFilePath, script] : [bashPath, script]
 
@@ -70,5 +71,16 @@ describe("cwd parameter", () => {
         const doesFileExist = fs.existsSync(path.join(testDirectoryPath, "testfile"))
 
         expect(doesFileExist).toBe(true)
+    })
+})
+
+describe("arguments", () => {
+    it("respects arguments passed in", async () => {
+
+        const result = cp.spawnSync("node", [bashPath, "sh", "-c", "(echo Hello || true)"])
+
+        expect(output.status).toEqual(0)
+        expect(output.stdout.indexOf("Hello")).toBeGreaterThanOrEqual(0)
+
     })
 })

--- a/__tests__/all-platforms/esy-bash-tests.js
+++ b/__tests__/all-platforms/esy-bash-tests.js
@@ -79,8 +79,8 @@ describe("arguments", () => {
 
         const result = cp.spawnSync("node", [bashPath, "sh", "-c", "(echo Hello || true)"])
 
-        expect(output.status).toEqual(0)
-        expect(output.stdout.indexOf("Hello")).toBeGreaterThanOrEqual(0)
+        expect(result.status).toEqual(0)
+        expect(result.stdout.indexOf("Hello")).toBeGreaterThanOrEqual(0)
 
     })
 })

--- a/bin/esy-bash.js
+++ b/bin/esy-bash.js
@@ -12,8 +12,11 @@ if (process.argv.length >= 3 && process.argv[2] === "--env") {
     }
 }
 
-const args = opts ? process.argv.slice(4).join(" ") : process.argv.slice(2).join(" ")
-console.log(args)
+
+const argsToSend = opts ? process.argv.slice(4) : process.argv.slice(2);
+const sanitizeArgs = (args) => args.map(a => "\"" + a + "\"").join(" ");
+
+const args = sanitizeArgs(argsToSend)
 
 bashExec(args, opts).then((code) => {
     process.exit(code)

--- a/bin/esy-bash.js
+++ b/bin/esy-bash.js
@@ -16,8 +16,8 @@ if (process.argv.length >= 3 && process.argv[2] === "--env") {
 const argsToSend = opts ? process.argv.slice(4) : process.argv.slice(2);
 const sanitizeArgs = (args) => args.map(a => "\"" + a + "\"").join(" ");
 
-const args = sanitizeArgs(argsToSend)
+const sanitizedArgs = argsToSend.length > 1 ? sanitizeArgs(argsToSend) : argsToSend[0]
 
-bashExec(args, opts).then((code) => {
+bashExec(sanitizedArgs, opts).then((code) => {
     process.exit(code)
 })


### PR DESCRIPTION
This came up in the context of the final jbuilder command: ["sh", "-c", "(esy-installer || true)"]. Because we simply concatenated the args, the command: "sh -c (esy-installer || true)" was giving an error. We need to maintain the separation of arguments to have this scenario work correctly.