### PR TITLE
Fix issue running command in some cases

### DIFF
--- a/bin/esy-bash.js
+++ b/bin/esy-bash.js
@@ -14,7 +14,7 @@ if (process.argv.length >= 3 && process.argv[2] === "--env") {
 
 
 const argsToSend = opts ? process.argv.slice(4) : process.argv.slice(2);
-const sanitizeArgs = (args) => args.map(a => "\"" + a + "\"").join(" ");
+const sanitizeArgs = (args) => args.map((a, idx) => idx === 0 ? a : "\"" + a + "\"").join(" ");
 
 const sanitizedArgs = argsToSend.length > 1 ? sanitizeArgs(argsToSend) : argsToSend[0]
 


### PR DESCRIPTION
This is a regression from the change to quote items (#5) - in some cases, quoting the first argument causes the command to fail to be run successfully.