### PR TITLE
Bug: Fix 'PATH' environment variable handling

### DIFF
--- a/__tests__/all-platforms/esy-bash-tests.js
+++ b/__tests__/all-platforms/esy-bash-tests.js
@@ -58,6 +58,18 @@ describe("--env: environment file", async () => {
         expect(output.status).toEqual(0)
         expect(output.stdout.indexOf("test-variable-value")).toBeGreaterThanOrEqual(0)
     })
+
+    it("loads PATH correctly from environment file", async () => {
+        const environmentFilePath = path.join(os.tmpdir(), "env-file")
+        const environment = JSON.stringify({
+            "PATH": "C:\\Users\\bryph\\.esy\\3_/i/opam__slash__jbuilder-1.0.0-beta20-6990b2ff/bin;C:\\Users\\bryph\\.esy\\3_/i/ocaml-4.6.4-092f4a41/bin;C:\\Users\\bryph\\.esy\\3_/i/esy_ocaml__slash__esy_installer-0.0.0-821110a6/bin;C:\\Users\\bryph\\.esy\\3_/i/esy_ocaml__slash__substs-0.0.1-49144bdf/bin;C:\\hello-world"
+        })
+        fs.writeFileSync(environmentFilePath, environment)
+
+        const output = await esyBashRun("echo $PATH", environmentFilePath)
+        expect(output.status).toEqual(0)
+        expect(output.stdout.indexOf("hello-world")).toBeGreaterThanOrEqual(0)
+    })
 })
 
 describe("cwd parameter", () => {

--- a/bash-exec.js
+++ b/bash-exec.js
@@ -15,7 +15,9 @@ let nonce = 0
 
 const remapPathsInEnvironment = (env) => {
     const val = Object.keys(env).reduce((prev, cur) => {
-        const mappedVariable = cur.toLowerCase() === "path" ? process.env["PATH"] + ";" + normalizePath(env[cur]) : normalizePath(env[cur])
+        // Normalize PATH variable
+        cur = cur.toLowerCase() === "path" ? "PATH" : cur
+        let mappedVariable = cur === "PATH" ? normalizePath(env[cur]): normalizePath(env[cur])
         return {
             ...prev,
             [cur]: mappedVariable,
@@ -46,6 +48,8 @@ const bashExec = (bashCommand, options) => {
             ...env,
             ...remappedPaths,
         }
+
+        env["path"] = env["Path"] = remappedPaths["PATH"]
     }
 
     const bashCommandWithDirectoryPreamble = `


### PR DESCRIPTION
__Issue:__ In some cases, when reading from an env file (provided by the `--env` flag), the `PATH` would not be reliably set.

__Defect:__ Depending on the environment, the `PATH` may have a variety of cases - `Path`, `path`, and `PATH`. There would be cases where we would explicitly set `PATH`, but another variant, like `Path` would take precedence.

__Fix:__ Explicitly set all path variants to rule out issues with this.