### PR TITLE
Fix escaping of '\' character

### DIFF
--- a/__tests__/all-platforms/esy-bash-tests.js
+++ b/__tests__/all-platforms/esy-bash-tests.js
@@ -5,7 +5,6 @@ const path = require("path")
 
 const { bashExec } = require("./../../index")
 
-
 const bashPath = path.join(__dirname, "..", "..", "bin", "esy-bash.js")
 
 const esyBashRun = async (script, envFilePath) => {
@@ -31,6 +30,12 @@ it("can pass basic statement to bash", async () => {
 
     expect(output.status).toBe(0)
     expect(output.stdout.indexOf("Hello World")).toBeGreaterThanOrEqual(0)
+})
+
+it("doesn't escape", async () => {
+    const output = await esyBashRun('echo "Hello\nworld"')
+    expect(output.status).toBe(0)
+    expect(output.stdout).toEqual("Hello" + "\n" + "world" + "\n")
 })
 
 it("can pass output to bash", async () => {

--- a/bash-exec.js
+++ b/bash-exec.js
@@ -38,8 +38,6 @@ const bashExec = (bashCommand, options) => {
 
     const cwd = options.cwd || process.cwd()
 
-
-    const sanitizedCommand = bashCommand.split("\\").join("/")
     log("esy-bash: executing bash command: " + sanitizedCommand + ` | nonce: ${nonce}`)
 
     let env = process.env

--- a/bash-exec.js
+++ b/bash-exec.js
@@ -38,9 +38,7 @@ const bashExec = (bashCommand, options) => {
 
     const cwd = options.cwd || process.cwd()
 
-
-    const sanitizedCommand = bashCommand
-    log("esy-bash: executing bash command: " + sanitizedCommand + ` | nonce: ${nonce}`)
+    log("esy-bash: executing bash command: " + bashCommand + ` | nonce: ${nonce}`)
 
     let env = process.env
 
@@ -61,7 +59,7 @@ const bashExec = (bashCommand, options) => {
     const bashCommandWithDirectoryPreamble = `
         # environment file: ${options.environmentFile}
         cd ${normalizePath(cwd)}
-        ${sanitizedCommand}
+        ${bashCommand}
     `
     const command = normalizeEndlines(bashCommandWithDirectoryPreamble)
 

--- a/bash-exec.js
+++ b/bash-exec.js
@@ -38,6 +38,8 @@ const bashExec = (bashCommand, options) => {
 
     const cwd = options.cwd || process.cwd()
 
+
+    const sanitizedCommand = bashCommand
     log("esy-bash: executing bash command: " + sanitizedCommand + ` | nonce: ${nonce}`)
 
     let env = process.env


### PR DESCRIPTION
Related to esy/esy#321 - looks like we are escaping the '\' character too aggressively, which is breaking some of our functionality (we need the `\n` character for the `curl` command - and this could also be breaking other functionality elsewhere)