### PR TITLE
Use native symlinks by default

### DIFF
--- a/bash-exec.js
+++ b/bash-exec.js
@@ -56,6 +56,11 @@ const bashExec = (bashCommand, options) => {
         env["path"] = env["Path"] = remappedPaths["PATH"]
     }
 
+    env = {
+        ...env,
+        "CYGWIN": "winsymlinks:nativestrict",
+    }
+
     const bashCommandWithDirectoryPreamble = `
         # environment file: ${options.environmentFile}
         cd ${normalizePath(cwd)}


### PR DESCRIPTION
__Issue:__ Some build scripts for `esy` require symbolic links - this is expected since we relocate builds or may propagate assets to different locations.

__Defect:__ Symbolic links did not behave in a predictable way on Windows. An easy way to see this is to run the `ln -s` command from Cygwin on a text file, and then try and read the text from the link - by default, Cygwin creates a text symbolic link, but most programs on Windows don't recognize this as a link.

https://stackoverflow.com/questions/18654162/enable-native-ntfs-symbolic-links-for-cygwin/18659632#18659632

__Fix:__ Set the `CYGWIN` environment variable to `winsymlinks:nativestrict`, which will create native symlinks.