### PR TITLE
Use hash code for scripts to ensure uniqueness

### DIFF
--- a/bash-exec.js
+++ b/bash-exec.js
@@ -32,8 +32,23 @@ const remapPathsInEnvironment = (env) => {
     return val
 }
 
+// From: https://stackoverflow.com/questions/7616461/generate-a-hash-from-string-in-javascript
+const getHashCode = (str) => {
+    var hash = 0, i, chr;
+  if (str.length === 0) return hash;
+  for (i = 0; i < str.length; i++) {
+          chr   = str.charCodeAt(i);
+          hash  = ((hash << 5) - hash) + chr;
+          hash |= 0; // Convert to 32bit integer
+    }
+  return hash;
+}
+
 const getUniqueId = (bashCommand) => {
-    return new Date().getTime();
+    const hash = getHashCode(bashCommand);
+    const time = new Date().getTime();
+
+    return `${hash.toString()}_${time.toString()}`
 }
 
 const bashExec = (bashCommand, options) => {

--- a/bash-exec.js
+++ b/bash-exec.js
@@ -32,6 +32,10 @@ const remapPathsInEnvironment = (env) => {
     return val
 }
 
+const getUniqueId = (bashCommand) => {
+    return new Date().getTime();
+}
+
 const bashExec = (bashCommand, options) => {
     options = options || {}
     nonce++
@@ -66,7 +70,7 @@ const bashExec = (bashCommand, options) => {
     const command = normalizeEndlines(bashCommandWithDirectoryPreamble)
 
     const tmp = os.tmpdir()
-    const temporaryScriptFilePath = path.join(tmp, `__esy-bash__${new Date().getTime()}__${nonce}__.sh`)
+    const temporaryScriptFilePath = path.join(tmp, `__esy-bash__${getUniqueId(bashCommand)}__${nonce}__.sh`)
 
     fs.writeFileSync(temporaryScriptFilePath, bashCommandWithDirectoryPreamble, "utf8")
     let normalizedPath = normalizePath(temporaryScriptFilePath)


### PR DESCRIPTION
Looking at the logs for `esy`, I saw cases like this:
```
error command failed: "tar" "xf" "/cygdrive/c/Users/appveyor/.esy/source-tarballs/safe-buffer__5.1.2__48565979.tgz" "-C" "/cygdrive/c/projects/esy/node_modules/safe-buffer"
      stderr:
               C:/Users/appveyor/AppData/Local/Temp/1/__esy-bash__1537458713337__1__.sh: line 5: unexpected EOF while looking for matching `"'
               C:/Users/appveyor/AppData/Local/Temp/1/__esy-bash__1537458713337__1__.sh: line 7: syntax error: unexpected end of file
               
      stdout:
               
esy: error, exiting...
     error running command
       installing rsvp@3.6.2 at C:\projects\esy\node_modules\rsvp
error command failed: "tar" "xf" "/cygdrive/c/Users/appveyor/.esy/source-tarballs/rsvp__3.6.2__01345564.tgz" "-C" "/cygdrive/c/projects/esy/node_modules/rsvp"
      stderr:
               C:/Users/appveyor/AppData/Local/Temp/1/__esy-bash__1537458713337__1__.sh: line 5: unexpected EOF while looking for matching `"'
               C:/Users/appveyor/AppData/Local/Temp/1/__esy-bash__1537458713337__1__.sh: line 7: syntax error: unexpected end of file
               
      stdout:
               
Command "esy install" failed with exit code 1. Retrying 2 of 3
info install 0.
```

It appears that _separate commands_ were both writing / executing from the same file - causing a race condition.

To fix this, I'm also introducing a hash of the command to keep the scripts unique.