### PR TITLE
Set noacl option when mounting win fs

### DIFF
--- a/bash-exec.js
+++ b/bash-exec.js
@@ -80,7 +80,9 @@ const bashExec = (bashCommand, options) => {
         "CYGWIN": "winsymlinks:nativestrict",
     }
 
+    // Setting noacl so that cygwin won't tamper with win permissions.
     const bashCommandWithDirectoryPreamble = `
+        mount -c /cygdrive -o binary,noacl,posix=0,user
         # environment file: ${options.environmentFile}
         cd ${normalizePath(cwd)}
         ${bashCommand}


### PR DESCRIPTION
This will prevent cygwin tampering with win permissions. This fixes the bug with ocamlbuild tarball installation in esy.

More info: https://stackoverflow.com/questions/5828037/cygwin-sets-file-permission-to-000