### PR TITLE
Package cygwin

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,6 +10,7 @@ install:
     - npm install
     - npm install -g yarn
     - npm install -g esy@next
+    # Install cygwin
     - npm run build-cygwin
     - cd re
     # Retry is necessary due to esy/esy#413 and esy/esy#414
@@ -23,7 +24,6 @@ environment:
     secure: h3hweU1D+fx2hyHtCSUHVkR7pKf7XpCEwC0/E/a+7vxnus3hArWb4w0WjynzOPJ+
 
 build_script:
-    # Install cygwin
     - esy build
     - esy b dune runtest
     # - cd ..

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,22 +6,24 @@ cache:
 
 install:
     # The x64 is required as a workaround for esy/esy#412
-    - ps: Install-Product node 8 x64
+    - ps: Install-Product node 9 x64
     - npm install
+    - npm install -g yarn
     - npm install -g esy@next
+    - npm run build-cygwin
     - cd re
     # Retry is necessary due to esy/esy#413 and esy/esy#414
     - appveyor-retry esy install
 
-# Workaround for esy/esy#388
+# 'max-old-space-size' needs to be set for large NPM uploads,
+# otherwise node will crash with an out-of-memory error
 environment:
-  HOME: C:\Users\appveyor
+  NODE_OPTIONS:--max-old-space-size=4096
   NPM_TOKEN:
     secure: h3hweU1D+fx2hyHtCSUHVkR7pKf7XpCEwC0/E/a+7vxnus3hArWb4w0WjynzOPJ+
 
 build_script:
     # Install cygwin
-    - npm run build-cygwin
     - esy build
     - esy b dune runtest
     # - cd ..

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -20,6 +20,8 @@ environment:
     secure: h3hweU1D+fx2hyHtCSUHVkR7pKf7XpCEwC0/E/a+7vxnus3hArWb4w0WjynzOPJ+
 
 build_script:
+    # Install cygwin
+    - npm run build-cygwin
     - esy build
     - esy b dune runtest
     # - cd ..

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,7 +8,6 @@ install:
     # The x64 is required as a workaround for esy/esy#412
     - ps: Install-Product node 9 x64
     - npm install
-    - npm install -g yarn
     - npm install -g esy@next
     # Install cygwin
     - npm run build-cygwin

--- a/build-cygwin.js
+++ b/build-cygwin.js
@@ -68,28 +68,6 @@ const install = async () => {
     })
 
     log(`Installation complete!`)
-
-    // Temporarily remove OPAM setting - 
-    // this should only be including in the `esy` bootstrapping.
-    // Long-term, we shouldn't actually need this, since `esy` can handle the install
-    // and loading the dependencies for us.
-
-    // log(`Setting up OPAM...`)
-    // const bashExecutablePath = path.join(destinationFolder, "bin", "bash.exe")
-    // const opamScriptPath = path.resolve(path.join(__dirname, "install-opam.sh"))
-
-    // cp.spawnSync(bashExecutablePath, [
-    //     "-l",
-    //     opamScriptPath,
-    // ], {
-    //     stdio: "inherit",
-    //     encoding: "utf-8",
-    //     env: {
-    //         ...process.env
-    //     }
-    // })
-
-    // log(`OPAM setup complete`)
 }
 
 if (os.platform() === "win32") {

--- a/build-cygwin.js
+++ b/build-cygwin.js
@@ -4,6 +4,7 @@ const mkdirp = require("mkdirp")
 const download = require("download")
 const cp = require("child_process")
 const rimraf = require("rimraf");
+const fs = require("fs-extra");
 
 const log = (msg) => console.log(msg)
 
@@ -77,6 +78,11 @@ const install = async () => {
     console.log("Deleting /var/cache...");
     rimraf.sync(path.join(__dirname, ".cygwin", "var", "cache"));
     console.log("Deletion successful!");
+
+    // Copy any overridden configuration scripts to the cygwin folder
+    console.log("Copying over defaults...");
+    fs.copySync(path.join(__dirname, "defaults"), path.join(__dirname, ".cygwin"));
+    console.log("Defaults copied successfully");
 }
 
 if (os.platform() === "win32") {

--- a/build-cygwin.js
+++ b/build-cygwin.js
@@ -3,6 +3,7 @@ const path = require("path")
 const mkdirp = require("mkdirp")
 const download = require("download")
 const cp = require("child_process")
+const rimraf = require("rimraf");
 
 const log = (msg) => console.log(msg)
 
@@ -68,6 +69,14 @@ const install = async () => {
     })
 
     log(`Installation complete!`)
+
+    // Run a command to test it out & create initial script files
+    cp.spawnSync(path.join(__dirname, ".cygwin", "bin", "bash.exe"), ["-c", "echo hi"]);
+
+    // Delete the /var/cache folder, since it's large and we don't need the cache at this point
+    console.log("Deleting /var/cache...");
+    rimraf.sync(path.join(__dirname, ".cygwin", "var", "cache"));
+    console.log("Deletion successful!");
 }
 
 if (os.platform() === "win32") {

--- a/esy.lock.json
+++ b/esy.lock.json
@@ -1,0 +1,6791 @@
+{
+  "hash": "5bf91e88f217b529622dc00c168578ab",
+  "root": "root@path:./package.json",
+  "node": {
+    "yauzl@2.10.0": {
+      "record": {
+        "name": "yauzl",
+        "version": "2.10.0",
+        "source":
+          "archive:https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz#sha1:c7eb17c93e112cb1086fa6d8e51fb0667b79a5f9",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [ "buffer-crc32@0.2.13", "fd-slicer@1.1.0" ]
+    },
+    "yargs-parser@9.0.2": {
+      "record": {
+        "name": "yargs-parser",
+        "version": "9.0.2",
+        "source":
+          "archive:https://registry.npmjs.org/yargs-parser/-/yargs-parser-9.0.2.tgz#sha1:9ccf6a43460fe4ed40a9bb68f48d43b8a68cc077",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [ "camelcase@4.1.0" ]
+    },
+    "yargs@11.1.0": {
+      "record": {
+        "name": "yargs",
+        "version": "11.1.0",
+        "source":
+          "archive:http://registry.npmjs.org/yargs/-/yargs-11.1.0.tgz#sha1:90b869934ed6e871115ea2ff58b03f4724ed2d77",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [
+        "cliui@4.1.0", "decamelize@1.2.0", "find-up@2.1.0",
+        "get-caller-file@1.0.3", "os-locale@2.1.0",
+        "require-directory@2.1.1", "require-main-filename@1.0.1",
+        "set-blocking@2.0.0", "string-width@2.1.1", "which-module@2.0.0",
+        "y18n@3.2.1", "yargs-parser@9.0.2"
+      ]
+    },
+    "yallist@3.0.2": {
+      "record": {
+        "name": "yallist",
+        "version": "3.0.2",
+        "source":
+          "archive:https://registry.npmjs.org/yallist/-/yallist-3.0.2.tgz#sha1:8452b4bb7e83c7c188d8041c1a837c773d6d8bb9",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": []
+    },
+    "yallist@2.1.2": {
+      "record": {
+        "name": "yallist",
+        "version": "2.1.2",
+        "source":
+          "archive:https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz#sha1:1c11f9218f076089a47dd512f93c6699a6a81d52",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": []
+    },
+    "y18n@3.2.1": {
+      "record": {
+        "name": "y18n",
+        "version": "3.2.1",
+        "source":
+          "archive:https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz#sha1:6d15fba884c08679c0d77e88e7759e811e07fa41",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": []
+    },
+    "xtend@4.0.1": {
+      "record": {
+        "name": "xtend",
+        "version": "4.0.1",
+        "source":
+          "archive:https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz#sha1:a5c6d532be656e23db820efb943a1f04998d63af",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": []
+    },
+    "xml-name-validator@3.0.0": {
+      "record": {
+        "name": "xml-name-validator",
+        "version": "3.0.0",
+        "source":
+          "archive:https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-3.0.0.tgz#sha1:6ae73e06de4d8c6e47f9fb181f78d648ad457c6a",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": []
+    },
+    "ws@5.2.2": {
+      "record": {
+        "name": "ws",
+        "version": "5.2.2",
+        "source":
+          "archive:https://registry.npmjs.org/ws/-/ws-5.2.2.tgz#sha1:dffef14866b8e8dc9133582514d1befaf96e980f",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [ "async-limiter@1.0.0" ]
+    },
+    "write-file-atomic@2.3.0": {
+      "record": {
+        "name": "write-file-atomic",
+        "version": "2.3.0",
+        "source":
+          "archive:https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.3.0.tgz#sha1:1ff61575c2e2a4e8e510d6fa4e243cce183999ab",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [
+        "graceful-fs@4.1.11", "imurmurhash@0.1.4", "signal-exit@3.0.2"
+      ]
+    },
+    "wrappy@1.0.2": {
+      "record": {
+        "name": "wrappy",
+        "version": "1.0.2",
+        "source":
+          "archive:https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz#sha1:b5243d8f3ec1aa35f1364605bc0d1036e30ab69f",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": []
+    },
+    "wrap-ansi@2.1.0": {
+      "record": {
+        "name": "wrap-ansi",
+        "version": "2.1.0",
+        "source":
+          "archive:http://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz#sha1:d8fc3d284dd05794fe84973caecdd1cf824fdd85",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [ "string-width@1.0.2", "strip-ansi@3.0.1" ]
+    },
+    "wordwrap@1.0.0": {
+      "record": {
+        "name": "wordwrap",
+        "version": "1.0.0",
+        "source":
+          "archive:https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz#sha1:27584810891456a4171c8d0226441ade90cbcaeb",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": []
+    },
+    "wordwrap@0.0.3": {
+      "record": {
+        "name": "wordwrap",
+        "version": "0.0.3",
+        "source":
+          "archive:https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz#sha1:a3d5da6cd5c0bc0008d37234bbaf1bed63059107",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": []
+    },
+    "wide-align@1.1.3": {
+      "record": {
+        "name": "wide-align",
+        "version": "1.1.3",
+        "source":
+          "archive:https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz#sha1:ae074e6bdc0c14a431e804e624549c633b000457",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [ "string-width@1.0.2" ]
+    },
+    "which-module@2.0.0": {
+      "record": {
+        "name": "which-module",
+        "version": "2.0.0",
+        "source":
+          "archive:https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz#sha1:d9ef07dce77b9902b8a3a8fa4b31c3e3f7e6e87a",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": []
+    },
+    "which@1.3.1": {
+      "record": {
+        "name": "which",
+        "version": "1.3.1",
+        "source":
+          "archive:https://registry.npmjs.org/which/-/which-1.3.1.tgz#sha1:a45043d54f5805316da8d62f9f50918d3da70b0a",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [ "isexe@2.0.0" ]
+    },
+    "whatwg-url@7.0.0": {
+      "record": {
+        "name": "whatwg-url",
+        "version": "7.0.0",
+        "source":
+          "archive:https://registry.npmjs.org/whatwg-url/-/whatwg-url-7.0.0.tgz#sha1:fde926fa54a599f3adf82dff25a9f7be02dc6edd",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [
+        "lodash.sortby@4.7.0", "tr46@1.0.1", "webidl-conversions@4.0.2"
+      ]
+    },
+    "whatwg-url@6.5.0": {
+      "record": {
+        "name": "whatwg-url",
+        "version": "6.5.0",
+        "source":
+          "archive:https://registry.npmjs.org/whatwg-url/-/whatwg-url-6.5.0.tgz#sha1:f2df02bff176fd65070df74ad5ccbb5a199965a8",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [
+        "lodash.sortby@4.7.0", "tr46@1.0.1", "webidl-conversions@4.0.2"
+      ]
+    },
+    "whatwg-mimetype@2.2.0": {
+      "record": {
+        "name": "whatwg-mimetype",
+        "version": "2.2.0",
+        "source":
+          "archive:https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-2.2.0.tgz#sha1:a3d58ef10b76009b042d03e25591ece89b88d171",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": []
+    },
+    "whatwg-encoding@1.0.5": {
+      "record": {
+        "name": "whatwg-encoding",
+        "version": "1.0.5",
+        "source":
+          "archive:https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-1.0.5.tgz#sha1:5abacf777c32166a51d085d6b4f3e7d27113ddb0",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [ "iconv-lite@0.4.24" ]
+    },
+    "webidl-conversions@4.0.2": {
+      "record": {
+        "name": "webidl-conversions",
+        "version": "4.0.2",
+        "source":
+          "archive:https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.2.tgz#sha1:a855980b1f0b6b359ba1d5d9fb39ae941faa63ad",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": []
+    },
+    "watch@0.18.0": {
+      "record": {
+        "name": "watch",
+        "version": "0.18.0",
+        "source":
+          "archive:https://registry.npmjs.org/watch/-/watch-0.18.0.tgz#sha1:28095476c6df7c90c963138990c0a5423eb4b986",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [ "exec-sh@0.2.2", "minimist@1.2.0" ]
+    },
+    "walker@1.0.7": {
+      "record": {
+        "name": "walker",
+        "version": "1.0.7",
+        "source":
+          "archive:https://registry.npmjs.org/walker/-/walker-1.0.7.tgz#sha1:2f7f9b8fd10d677262b18a884e28d19618e028fb",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [ "makeerror@1.0.11" ]
+    },
+    "w3c-hr-time@1.0.1": {
+      "record": {
+        "name": "w3c-hr-time",
+        "version": "1.0.1",
+        "source":
+          "archive:https://registry.npmjs.org/w3c-hr-time/-/w3c-hr-time-1.0.1.tgz#sha1:82ac2bff63d950ea9e3189a58a65625fedf19045",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [ "browser-process-hrtime@0.1.3" ]
+    },
+    "verror@1.10.0": {
+      "record": {
+        "name": "verror",
+        "version": "1.10.0",
+        "source":
+          "archive:https://registry.npmjs.org/verror/-/verror-1.10.0.tgz#sha1:3a105ca17053af55d6e270c1f8288682e18da400",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [
+        "assert-plus@1.0.0", "core-util-is@1.0.2", "extsprintf@1.3.0"
+      ]
+    },
+    "validate-npm-package-license@3.0.4": {
+      "record": {
+        "name": "validate-npm-package-license",
+        "version": "3.0.4",
+        "source":
+          "archive:https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz#sha1:fc91f6b9c7ba15c857f4cb2c5defeec39d4f410a",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [ "spdx-correct@3.0.2", "spdx-expression-parse@3.0.0" ]
+    },
+    "uuid@3.3.2": {
+      "record": {
+        "name": "uuid",
+        "version": "3.3.2",
+        "source":
+          "archive:https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz#sha1:1b4af4955eb3077c501c23872fc6513811587131",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": []
+    },
+    "util.promisify@1.0.0": {
+      "record": {
+        "name": "util.promisify",
+        "version": "1.0.0",
+        "source":
+          "archive:https://registry.npmjs.org/util.promisify/-/util.promisify-1.0.0.tgz#sha1:440f7165a459c9a16dc145eb8e72f35687097030",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [
+        "define-properties@1.1.3", "object.getownpropertydescriptors@2.0.3"
+      ]
+    },
+    "util-deprecate@1.0.2": {
+      "record": {
+        "name": "util-deprecate",
+        "version": "1.0.2",
+        "source":
+          "archive:https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz#sha1:450d4dc9fa70de732762fbd2d4a28981419a0ccf",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": []
+    },
+    "use@3.1.1": {
+      "record": {
+        "name": "use",
+        "version": "3.1.1",
+        "source":
+          "archive:https://registry.npmjs.org/use/-/use-3.1.1.tgz#sha1:d50c8cac79a19fbc20f2911f56eb973f4e10070f",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": []
+    },
+    "url-to-options@1.0.1": {
+      "record": {
+        "name": "url-to-options",
+        "version": "1.0.1",
+        "source":
+          "archive:https://registry.npmjs.org/url-to-options/-/url-to-options-1.0.1.tgz#sha1:1505a03a289a48cbd7a434efbaeec5055f5633a9",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": []
+    },
+    "url-parse-lax@3.0.0": {
+      "record": {
+        "name": "url-parse-lax",
+        "version": "3.0.0",
+        "source":
+          "archive:https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-3.0.0.tgz#sha1:16b5cafc07dbe3676c1b1999177823d6503acb0c",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [ "prepend-http@2.0.0" ]
+    },
+    "urix@0.1.0": {
+      "record": {
+        "name": "urix",
+        "version": "0.1.0",
+        "source":
+          "archive:https://registry.npmjs.org/urix/-/urix-0.1.0.tgz#sha1:da937f7a62e21fec1fd18d49b35c2935067a6c72",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": []
+    },
+    "unset-value@1.0.0": {
+      "record": {
+        "name": "unset-value",
+        "version": "1.0.0",
+        "source":
+          "archive:https://registry.npmjs.org/unset-value/-/unset-value-1.0.0.tgz#sha1:8376873f7d2335179ffb1e6fc3a8ed0dfc8ab559",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [ "has-value@0.3.1", "isobject@3.0.1" ]
+    },
+    "union-value@1.0.0": {
+      "record": {
+        "name": "union-value",
+        "version": "1.0.0",
+        "source":
+          "archive:https://registry.npmjs.org/union-value/-/union-value-1.0.0.tgz#sha1:5c71c34cb5bad5dcebe3ea0cd08207ba5aa1aea4",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [
+        "arr-union@3.1.0", "get-value@2.0.6", "is-extendable@0.1.1",
+        "set-value@0.4.3"
+      ]
+    },
+    "unbzip2-stream@1.3.1": {
+      "record": {
+        "name": "unbzip2-stream",
+        "version": "1.3.1",
+        "source":
+          "archive:https://registry.npmjs.org/unbzip2-stream/-/unbzip2-stream-1.3.1.tgz#sha1:7854da51622a7e63624221196357803b552966a1",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [ "buffer@3.6.0", "through@2.3.8" ]
+    },
+    "uglify-js@3.4.9": {
+      "record": {
+        "name": "uglify-js",
+        "version": "3.4.9",
+        "source":
+          "archive:https://registry.npmjs.org/uglify-js/-/uglify-js-3.4.9.tgz#sha1:af02f180c1207d76432e473ed24a28f4a782bae3",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [ "commander@2.17.1", "source-map@0.6.1" ]
+    },
+    "type-check@0.3.2": {
+      "record": {
+        "name": "type-check",
+        "version": "0.3.2",
+        "source":
+          "archive:https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz#sha1:5884cab512cf1d355e3fb784f30804b2b520db72",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [ "prelude-ls@1.1.2" ]
+    },
+    "tweetnacl@0.14.5": {
+      "record": {
+        "name": "tweetnacl",
+        "version": "0.14.5",
+        "source":
+          "archive:https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz#sha1:5ae68177f192d4456269d108afa93ff8743f4f64",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": []
+    },
+    "tunnel-agent@0.6.0": {
+      "record": {
+        "name": "tunnel-agent",
+        "version": "0.6.0",
+        "source":
+          "archive:https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz#sha1:27a5dea06b36b04a0a9966774b290868f0fc40fd",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [ "safe-buffer@5.1.2" ]
+    },
+    "trim-right@1.0.1": {
+      "record": {
+        "name": "trim-right",
+        "version": "1.0.1",
+        "source":
+          "archive:https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz#sha1:cb2e1203067e0c8de1f614094b9fe45704ea6003",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": []
+    },
+    "trim-repeated@1.0.0": {
+      "record": {
+        "name": "trim-repeated",
+        "version": "1.0.0",
+        "source":
+          "archive:https://registry.npmjs.org/trim-repeated/-/trim-repeated-1.0.0.tgz#sha1:e3646a2ea4e891312bf7eace6cfb05380bc01c21",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [ "escape-string-regexp@1.0.5" ]
+    },
+    "tr46@1.0.1": {
+      "record": {
+        "name": "tr46",
+        "version": "1.0.1",
+        "source":
+          "archive:https://registry.npmjs.org/tr46/-/tr46-1.0.1.tgz#sha1:a8b13fd6bfd2489519674ccde55ba3693b706d09",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [ "punycode@2.1.1" ]
+    },
+    "tough-cookie@2.4.3": {
+      "record": {
+        "name": "tough-cookie",
+        "version": "2.4.3",
+        "source":
+          "archive:https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.4.3.tgz#sha1:53f36da3f47783b0925afa06ff9f3b165280f781",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [ "psl@1.1.29", "punycode@1.4.1" ]
+    },
+    "to-regex-range@2.1.1": {
+      "record": {
+        "name": "to-regex-range",
+        "version": "2.1.1",
+        "source":
+          "archive:https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz#sha1:7c80c17b9dfebe599e27367e0d4dd5590141db38",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [ "is-number@3.0.0", "repeat-string@1.6.1" ]
+    },
+    "to-regex@3.0.2": {
+      "record": {
+        "name": "to-regex",
+        "version": "3.0.2",
+        "source":
+          "archive:https://registry.npmjs.org/to-regex/-/to-regex-3.0.2.tgz#sha1:13cfdd9b336552f30b51f33a8ae1b42a7a7599ce",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [
+        "define-property@2.0.2", "extend-shallow@3.0.2", "regex-not@1.0.2",
+        "safe-regex@1.1.0"
+      ]
+    },
+    "to-object-path@0.3.0": {
+      "record": {
+        "name": "to-object-path",
+        "version": "0.3.0",
+        "source":
+          "archive:https://registry.npmjs.org/to-object-path/-/to-object-path-0.3.0.tgz#sha1:297588b7b0e7e0ac08e04e672f85c1f4999e17af",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [ "kind-of@3.2.2" ]
+    },
+    "to-fast-properties@1.0.3": {
+      "record": {
+        "name": "to-fast-properties",
+        "version": "1.0.3",
+        "source":
+          "archive:https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz#sha1:b83571fa4d8c25b82e231b06e3a3055de4ca1a47",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": []
+    },
+    "to-buffer@1.1.1": {
+      "record": {
+        "name": "to-buffer",
+        "version": "1.1.1",
+        "source":
+          "archive:https://registry.npmjs.org/to-buffer/-/to-buffer-1.1.1.tgz#sha1:493bd48f62d7c43fcded313a03dcadb2e1213a80",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": []
+    },
+    "tmpl@1.0.4": {
+      "record": {
+        "name": "tmpl",
+        "version": "1.0.4",
+        "source":
+          "archive:https://registry.npmjs.org/tmpl/-/tmpl-1.0.4.tgz#sha1:23640dd7b42d00433911140820e5cf440e521dd1",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": []
+    },
+    "timed-out@4.0.1": {
+      "record": {
+        "name": "timed-out",
+        "version": "4.0.1",
+        "source":
+          "archive:https://registry.npmjs.org/timed-out/-/timed-out-4.0.1.tgz#sha1:f32eacac5a175bea25d7fab565ab3ed8741ef56f",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": []
+    },
+    "through@2.3.8": {
+      "record": {
+        "name": "through",
+        "version": "2.3.8",
+        "source":
+          "archive:http://registry.npmjs.org/through/-/through-2.3.8.tgz#sha1:0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": []
+    },
+    "throat@4.1.0": {
+      "record": {
+        "name": "throat",
+        "version": "4.1.0",
+        "source":
+          "archive:https://registry.npmjs.org/throat/-/throat-4.1.0.tgz#sha1:89037cbc92c56ab18926e6ba4cbb200e15672a6a",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": []
+    },
+    "test-exclude@4.2.3": {
+      "record": {
+        "name": "test-exclude",
+        "version": "4.2.3",
+        "source":
+          "archive:https://registry.npmjs.org/test-exclude/-/test-exclude-4.2.3.tgz#sha1:a9a5e64474e4398339245a0a769ad7c2f4a97c20",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [
+        "arrify@1.0.1", "micromatch@2.3.11", "object-assign@4.1.1",
+        "read-pkg-up@1.0.1", "require-main-filename@1.0.1"
+      ]
+    },
+    "tar-stream@1.6.2": {
+      "record": {
+        "name": "tar-stream",
+        "version": "1.6.2",
+        "source":
+          "archive:https://registry.npmjs.org/tar-stream/-/tar-stream-1.6.2.tgz#sha1:8ea55dab37972253d9a9af90fdcd559ae435c555",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [
+        "bl@1.2.2", "buffer-alloc@1.2.0", "end-of-stream@1.4.1",
+        "fs-constants@1.0.0", "readable-stream@2.3.6", "to-buffer@1.1.1",
+        "xtend@4.0.1"
+      ]
+    },
+    "tar@4.4.6": {
+      "record": {
+        "name": "tar",
+        "version": "4.4.6",
+        "source":
+          "archive:https://registry.npmjs.org/tar/-/tar-4.4.6.tgz#sha1:63110f09c00b4e60ac8bcfe1bf3c8660235fbc9b",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [
+        "chownr@1.1.1", "fs-minipass@1.2.5", "minipass@2.3.4",
+        "minizlib@1.1.1", "mkdirp@0.5.1", "safe-buffer@5.1.2",
+        "yallist@3.0.2"
+      ]
+    },
+    "symbol-tree@3.2.2": {
+      "record": {
+        "name": "symbol-tree",
+        "version": "3.2.2",
+        "source":
+          "archive:https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.2.tgz#sha1:ae27db38f660a7ae2e1c3b7d1bc290819b8519e6",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": []
+    },
+    "supports-color@5.5.0": {
+      "record": {
+        "name": "supports-color",
+        "version": "5.5.0",
+        "source":
+          "archive:https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz#sha1:e2e69a44ac8772f78a1ec0b35b689df6530efc8f",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [ "has-flag@3.0.0" ]
+    },
+    "supports-color@3.2.3": {
+      "record": {
+        "name": "supports-color",
+        "version": "3.2.3",
+        "source":
+          "archive:https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz#sha1:65ac0504b3954171d8a64946b2ae3cbb8a5f54f6",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [ "has-flag@1.0.0" ]
+    },
+    "supports-color@2.0.0": {
+      "record": {
+        "name": "supports-color",
+        "version": "2.0.0",
+        "source":
+          "archive:https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz#sha1:535d045ce6b6363fa40117084629995e9df324c7",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": []
+    },
+    "strip-outer@1.0.1": {
+      "record": {
+        "name": "strip-outer",
+        "version": "1.0.1",
+        "source":
+          "archive:https://registry.npmjs.org/strip-outer/-/strip-outer-1.0.1.tgz#sha1:b2fd2abf6604b9d1e6013057195df836b8a9d631",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [ "escape-string-regexp@1.0.5" ]
+    },
+    "strip-json-comments@2.0.1": {
+      "record": {
+        "name": "strip-json-comments",
+        "version": "2.0.1",
+        "source":
+          "archive:https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz#sha1:3c531942e908c2697c0ec344858c286c7ca0a60a",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": []
+    },
+    "strip-eof@1.0.0": {
+      "record": {
+        "name": "strip-eof",
+        "version": "1.0.0",
+        "source":
+          "archive:https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz#sha1:bb43ff5598a6eb05d89b59fcd129c983313606bf",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": []
+    },
+    "strip-dirs@2.1.0": {
+      "record": {
+        "name": "strip-dirs",
+        "version": "2.1.0",
+        "source":
+          "archive:https://registry.npmjs.org/strip-dirs/-/strip-dirs-2.1.0.tgz#sha1:4987736264fc344cf20f6c34aca9d13d1d4ed6c5",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [ "is-natural-number@4.0.1" ]
+    },
+    "strip-bom@3.0.0": {
+      "record": {
+        "name": "strip-bom",
+        "version": "3.0.0",
+        "source":
+          "archive:https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz#sha1:2334c18e9c759f7bdd56fdef7e9ae3d588e68ed3",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": []
+    },
+    "strip-bom@2.0.0": {
+      "record": {
+        "name": "strip-bom",
+        "version": "2.0.0",
+        "source":
+          "archive:https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz#sha1:6219a85616520491f35788bdbf1447a99c7e6b0e",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [ "is-utf8@0.2.1" ]
+    },
+    "strip-ansi@4.0.0": {
+      "record": {
+        "name": "strip-ansi",
+        "version": "4.0.0",
+        "source":
+          "archive:https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz#sha1:a8479022eb1ac368a871389b635262c505ee368f",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [ "ansi-regex@3.0.0" ]
+    },
+    "strip-ansi@3.0.1": {
+      "record": {
+        "name": "strip-ansi",
+        "version": "3.0.1",
+        "source":
+          "archive:http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz#sha1:6a385fb8853d952d5ff05d0e8aaf94278dc63dcf",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [ "ansi-regex@2.1.1" ]
+    },
+    "string_decoder@1.1.1": {
+      "record": {
+        "name": "string_decoder",
+        "version": "1.1.1",
+        "source":
+          "archive:https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz#sha1:9cf1611ba62685d7030ae9e4ba34149c3af03fc8",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [ "safe-buffer@5.1.2" ]
+    },
+    "string-width@2.1.1": {
+      "record": {
+        "name": "string-width",
+        "version": "2.1.1",
+        "source":
+          "archive:https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz#sha1:ab93f27a8dc13d28cac815c462143a6d9012ae9e",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [ "is-fullwidth-code-point@2.0.0", "strip-ansi@4.0.0" ]
+    },
+    "string-width@1.0.2": {
+      "record": {
+        "name": "string-width",
+        "version": "1.0.2",
+        "source":
+          "archive:https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz#sha1:118bdf5b8cdc51a2a7e70d211e07e2b0b9b107d3",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [
+        "code-point-at@1.1.0", "is-fullwidth-code-point@1.0.0",
+        "strip-ansi@3.0.1"
+      ]
+    },
+    "string-length@2.0.0": {
+      "record": {
+        "name": "string-length",
+        "version": "2.0.0",
+        "source":
+          "archive:https://registry.npmjs.org/string-length/-/string-length-2.0.0.tgz#sha1:d40dbb686a3ace960c1cffca562bf2c45f8363ed",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [ "astral-regex@1.0.0", "strip-ansi@4.0.0" ]
+    },
+    "strict-uri-encode@1.1.0": {
+      "record": {
+        "name": "strict-uri-encode",
+        "version": "1.1.0",
+        "source":
+          "archive:https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz#sha1:279b225df1d582b1f54e65addd4352e18faa0713",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": []
+    },
+    "stealthy-require@1.1.1": {
+      "record": {
+        "name": "stealthy-require",
+        "version": "1.1.1",
+        "source":
+          "archive:https://registry.npmjs.org/stealthy-require/-/stealthy-require-1.1.1.tgz#sha1:35b09875b4ff49f26a777e509b3090a3226bf24b",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": []
+    },
+    "static-extend@0.1.2": {
+      "record": {
+        "name": "static-extend",
+        "version": "0.1.2",
+        "source":
+          "archive:https://registry.npmjs.org/static-extend/-/static-extend-0.1.2.tgz#sha1:60809c39cbff55337226fd5e0b520f341f1fb5c6",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [ "define-property@0.2.5", "object-copy@0.1.0" ]
+    },
+    "stack-utils@1.0.1": {
+      "record": {
+        "name": "stack-utils",
+        "version": "1.0.1",
+        "source":
+          "archive:https://registry.npmjs.org/stack-utils/-/stack-utils-1.0.1.tgz#sha1:d4f33ab54e8e38778b0ca5cfd3b3afb12db68620",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": []
+    },
+    "sshpk@1.15.1": {
+      "record": {
+        "name": "sshpk",
+        "version": "1.15.1",
+        "source":
+          "archive:https://registry.npmjs.org/sshpk/-/sshpk-1.15.1.tgz#sha1:b79a089a732e346c6e0714830f36285cd38191a2",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [
+        "asn1@0.2.4", "assert-plus@1.0.0", "bcrypt-pbkdf@1.0.2",
+        "dashdash@1.14.1", "ecc-jsbn@0.1.2", "getpass@0.1.7", "jsbn@0.1.1",
+        "safer-buffer@2.1.2", "tweetnacl@0.14.5"
+      ]
+    },
+    "sprintf-js@1.0.3": {
+      "record": {
+        "name": "sprintf-js",
+        "version": "1.0.3",
+        "source":
+          "archive:https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz#sha1:04e6926f662895354f3dd015203633b857297e2c",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": []
+    },
+    "split-string@3.1.0": {
+      "record": {
+        "name": "split-string",
+        "version": "3.1.0",
+        "source":
+          "archive:https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz#sha1:7cb09dda3a86585705c64b39a6466038682e8fe2",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [ "extend-shallow@3.0.2" ]
+    },
+    "spdx-license-ids@3.0.1": {
+      "record": {
+        "name": "spdx-license-ids",
+        "version": "3.0.1",
+        "source":
+          "archive:https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.1.tgz#sha1:e2a303236cac54b04031fa7a5a79c7e701df852f",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": []
+    },
+    "spdx-expression-parse@3.0.0": {
+      "record": {
+        "name": "spdx-expression-parse",
+        "version": "3.0.0",
+        "source":
+          "archive:https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz#sha1:99e119b7a5da00e05491c9fa338b7904823b41d0",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [ "spdx-exceptions@2.2.0", "spdx-license-ids@3.0.1" ]
+    },
+    "spdx-exceptions@2.2.0": {
+      "record": {
+        "name": "spdx-exceptions",
+        "version": "2.2.0",
+        "source":
+          "archive:https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.2.0.tgz#sha1:2ea450aee74f2a89bfb94519c07fcd6f41322977",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": []
+    },
+    "spdx-correct@3.0.2": {
+      "record": {
+        "name": "spdx-correct",
+        "version": "3.0.2",
+        "source":
+          "archive:https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.0.2.tgz#sha1:19bb409e91b47b1ad54159243f7312a858db3c2e",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [
+        "spdx-expression-parse@3.0.0", "spdx-license-ids@3.0.1"
+      ]
+    },
+    "source-map-url@0.4.0": {
+      "record": {
+        "name": "source-map-url",
+        "version": "0.4.0",
+        "source":
+          "archive:https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.0.tgz#sha1:3e935d7ddd73631b97659956d55128e87b5084a3",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": []
+    },
+    "source-map-support@0.5.9": {
+      "record": {
+        "name": "source-map-support",
+        "version": "0.5.9",
+        "source":
+          "archive:https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.9.tgz#sha1:41bc953b2534267ea2d605bccfa7bfa3111ced5f",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [ "buffer-from@1.1.1", "source-map@0.6.1" ]
+    },
+    "source-map-support@0.4.18": {
+      "record": {
+        "name": "source-map-support",
+        "version": "0.4.18",
+        "source":
+          "archive:https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.18.tgz#sha1:0286a6de8be42641338594e97ccea75f0a2c585f",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [ "source-map@0.5.7" ]
+    },
+    "source-map-resolve@0.5.2": {
+      "record": {
+        "name": "source-map-resolve",
+        "version": "0.5.2",
+        "source":
+          "archive:https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.2.tgz#sha1:72e2cc34095543e43b2c62b2c4c10d4a9054f259",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [
+        "atob@2.1.2", "decode-uri-component@0.2.0", "resolve-url@0.2.1",
+        "source-map-url@0.4.0", "urix@0.1.0"
+      ]
+    },
+    "source-map@0.6.1": {
+      "record": {
+        "name": "source-map",
+        "version": "0.6.1",
+        "source":
+          "archive:https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz#sha1:74722af32e9614e9c287a8d0bbde48b5e2f1a263",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": []
+    },
+    "source-map@0.5.7": {
+      "record": {
+        "name": "source-map",
+        "version": "0.5.7",
+        "source":
+          "archive:https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz#sha1:8a039d2d1021d22d1ea14c80d8ea468ba2ef3fcc",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": []
+    },
+    "sort-keys-length@1.0.1": {
+      "record": {
+        "name": "sort-keys-length",
+        "version": "1.0.1",
+        "source":
+          "archive:https://registry.npmjs.org/sort-keys-length/-/sort-keys-length-1.0.1.tgz#sha1:9cb6f4f4e9e48155a6aa0671edd336ff1479a188",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [ "sort-keys@1.1.2" ]
+    },
+    "sort-keys@2.0.0": {
+      "record": {
+        "name": "sort-keys",
+        "version": "2.0.0",
+        "source":
+          "archive:https://registry.npmjs.org/sort-keys/-/sort-keys-2.0.0.tgz#sha1:658535584861ec97d730d6cf41822e1f56684128",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [ "is-plain-obj@1.1.0" ]
+    },
+    "sort-keys@1.1.2": {
+      "record": {
+        "name": "sort-keys",
+        "version": "1.1.2",
+        "source":
+          "archive:https://registry.npmjs.org/sort-keys/-/sort-keys-1.1.2.tgz#sha1:441b6d4d346798f1b4e49e8920adfba0e543f9ad",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [ "is-plain-obj@1.1.0" ]
+    },
+    "snapdragon-util@3.0.1": {
+      "record": {
+        "name": "snapdragon-util",
+        "version": "3.0.1",
+        "source":
+          "archive:https://registry.npmjs.org/snapdragon-util/-/snapdragon-util-3.0.1.tgz#sha1:f956479486f2acd79700693f6f7b805e45ab56e2",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [ "kind-of@3.2.2" ]
+    },
+    "snapdragon-node@2.1.1": {
+      "record": {
+        "name": "snapdragon-node",
+        "version": "2.1.1",
+        "source":
+          "archive:https://registry.npmjs.org/snapdragon-node/-/snapdragon-node-2.1.1.tgz#sha1:6c175f86ff14bdb0724563e8f3c1b021a286853b",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [
+        "define-property@1.0.0", "isobject@3.0.1", "snapdragon-util@3.0.1"
+      ]
+    },
+    "snapdragon@0.8.2": {
+      "record": {
+        "name": "snapdragon",
+        "version": "0.8.2",
+        "source":
+          "archive:https://registry.npmjs.org/snapdragon/-/snapdragon-0.8.2.tgz#sha1:64922e7c565b0e14204ba1aa7d6964278d25182d",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [
+        "base@0.11.2", "debug@2.6.9", "define-property@0.2.5",
+        "extend-shallow@2.0.1", "map-cache@0.2.2", "source-map@0.5.7",
+        "source-map-resolve@0.5.2", "use@3.1.1"
+      ]
+    },
+    "slash@1.0.0": {
+      "record": {
+        "name": "slash",
+        "version": "1.0.0",
+        "source":
+          "archive:https://registry.npmjs.org/slash/-/slash-1.0.0.tgz#sha1:c41f2f6c39fc16d1cd17ad4b5d896114ae470d55",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": []
+    },
+    "sisteransi@0.1.1": {
+      "record": {
+        "name": "sisteransi",
+        "version": "0.1.1",
+        "source":
+          "archive:https://registry.npmjs.org/sisteransi/-/sisteransi-0.1.1.tgz#sha1:5431447d5f7d1675aac667ccd0b865a4994cb3ce",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": []
+    },
+    "signal-exit@3.0.2": {
+      "record": {
+        "name": "signal-exit",
+        "version": "3.0.2",
+        "source":
+          "archive:https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz#sha1:b5fdc08f1287ea1178628e415e25132b73646c6d",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": []
+    },
+    "shellwords@0.1.1": {
+      "record": {
+        "name": "shellwords",
+        "version": "0.1.1",
+        "source":
+          "archive:https://registry.npmjs.org/shellwords/-/shellwords-0.1.1.tgz#sha1:d6b9181c1a48d397324c84871efbcfc73fc0654b",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": []
+    },
+    "shebang-regex@1.0.0": {
+      "record": {
+        "name": "shebang-regex",
+        "version": "1.0.0",
+        "source":
+          "archive:https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz#sha1:da42f49740c0b42db2ca9728571cb190c98efea3",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": []
+    },
+    "shebang-command@1.2.0": {
+      "record": {
+        "name": "shebang-command",
+        "version": "1.2.0",
+        "source":
+          "archive:https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz#sha1:44aac65b695b03398968c39f363fee5deafdf1ea",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [ "shebang-regex@1.0.0" ]
+    },
+    "set-value@2.0.0": {
+      "record": {
+        "name": "set-value",
+        "version": "2.0.0",
+        "source":
+          "archive:https://registry.npmjs.org/set-value/-/set-value-2.0.0.tgz#sha1:71ae4a88f0feefbbf52d1ea604f3fb315ebb6274",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [
+        "extend-shallow@2.0.1", "is-extendable@0.1.1",
+        "is-plain-object@2.0.4", "split-string@3.1.0"
+      ]
+    },
+    "set-value@0.4.3": {
+      "record": {
+        "name": "set-value",
+        "version": "0.4.3",
+        "source":
+          "archive:https://registry.npmjs.org/set-value/-/set-value-0.4.3.tgz#sha1:7db08f9d3d22dc7f78e53af3c3bf4666ecdfccf1",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [
+        "extend-shallow@2.0.1", "is-extendable@0.1.1",
+        "is-plain-object@2.0.4", "to-object-path@0.3.0"
+      ]
+    },
+    "set-blocking@2.0.0": {
+      "record": {
+        "name": "set-blocking",
+        "version": "2.0.0",
+        "source":
+          "archive:https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz#sha1:045f9782d011ae9a6803ddd382b24392b3d890f7",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": []
+    },
+    "semver@5.6.0": {
+      "record": {
+        "name": "semver",
+        "version": "5.6.0",
+        "source":
+          "archive:https://registry.npmjs.org/semver/-/semver-5.6.0.tgz#sha1:7e74256fbaa49c75aa7c7a205cc22799cac80004",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": []
+    },
+    "seek-bzip@1.0.5": {
+      "record": {
+        "name": "seek-bzip",
+        "version": "1.0.5",
+        "source":
+          "archive:https://registry.npmjs.org/seek-bzip/-/seek-bzip-1.0.5.tgz#sha1:cfe917cb3d274bcffac792758af53173eb1fabdc",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [ "commander@2.8.1" ]
+    },
+    "sax@1.2.4": {
+      "record": {
+        "name": "sax",
+        "version": "1.2.4",
+        "source":
+          "archive:https://registry.npmjs.org/sax/-/sax-1.2.4.tgz#sha1:2816234e2378bddc4e5354fab5caa895df7100d9",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": []
+    },
+    "sane@2.5.2": {
+      "record": {
+        "name": "sane",
+        "version": "2.5.2",
+        "source":
+          "archive:https://registry.npmjs.org/sane/-/sane-2.5.2.tgz#sha1:b4dc1861c21b427e929507a3e751e2a2cb8ab3fa",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [
+        "anymatch@2.0.0", "capture-exit@1.2.0", "exec-sh@0.2.2",
+        "fb-watchman@2.0.0", "fsevents@1.2.4", "micromatch@3.1.10",
+        "minimist@1.2.0", "walker@1.0.7", "watch@0.18.0"
+      ]
+    },
+    "safer-buffer@2.1.2": {
+      "record": {
+        "name": "safer-buffer",
+        "version": "2.1.2",
+        "source":
+          "archive:https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz#sha1:44fa161b0187b9549dd84bb91802f9bd8385cd6a",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": []
+    },
+    "safe-regex@1.1.0": {
+      "record": {
+        "name": "safe-regex",
+        "version": "1.1.0",
+        "source":
+          "archive:https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz#sha1:40a3669f3b077d1e943d44629e157dd48023bf2e",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [ "ret@0.1.15" ]
+    },
+    "safe-buffer@5.1.2": {
+      "record": {
+        "name": "safe-buffer",
+        "version": "5.1.2",
+        "source":
+          "archive:https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz#sha1:991ec69d296e0313747d59bdfd2b745c35f8828d",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": []
+    },
+    "rsvp@3.6.2": {
+      "record": {
+        "name": "rsvp",
+        "version": "3.6.2",
+        "source":
+          "archive:https://registry.npmjs.org/rsvp/-/rsvp-3.6.2.tgz#sha1:2e96491599a96cde1b515d5674a8f7a91452926a",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": []
+    },
+    "root@path:./package.json": {
+      "record": {
+        "name": "root",
+        "version": "path:./package.json",
+        "source": "path:./package.json",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [ "download@7.1.0", "jest@23.6.0", "mkdirp@0.5.1" ]
+    },
+    "rimraf@2.6.2": {
+      "record": {
+        "name": "rimraf",
+        "version": "2.6.2",
+        "source":
+          "archive:https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz#sha1:2ed8150d24a16ea8651e6d6ef0f47c4158ce7a36",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [ "glob@7.1.3" ]
+    },
+    "ret@0.1.15": {
+      "record": {
+        "name": "ret",
+        "version": "0.1.15",
+        "source":
+          "archive:https://registry.npmjs.org/ret/-/ret-0.1.15.tgz#sha1:b8a4825d5bdb1fc3f6f53c2bc33f81388681c7bc",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": []
+    },
+    "responselike@1.0.2": {
+      "record": {
+        "name": "responselike",
+        "version": "1.0.2",
+        "source":
+          "archive:https://registry.npmjs.org/responselike/-/responselike-1.0.2.tgz#sha1:918720ef3b631c5642be068f15ade5a46f4ba1e7",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [ "lowercase-keys@1.0.0" ]
+    },
+    "resolve-url@0.2.1": {
+      "record": {
+        "name": "resolve-url",
+        "version": "0.2.1",
+        "source":
+          "archive:https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz#sha1:2c637fe77c893afd2a663fe21aa9080068e2052a",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": []
+    },
+    "resolve-from@3.0.0": {
+      "record": {
+        "name": "resolve-from",
+        "version": "3.0.0",
+        "source":
+          "archive:https://registry.npmjs.org/resolve-from/-/resolve-from-3.0.0.tgz#sha1:b22c7af7d9d6881bc8b6e653335eebcb0a188748",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": []
+    },
+    "resolve-cwd@2.0.0": {
+      "record": {
+        "name": "resolve-cwd",
+        "version": "2.0.0",
+        "source":
+          "archive:https://registry.npmjs.org/resolve-cwd/-/resolve-cwd-2.0.0.tgz#sha1:00a9f7387556e27038eae232caa372a6a59b665a",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [ "resolve-from@3.0.0" ]
+    },
+    "resolve@1.1.7": {
+      "record": {
+        "name": "resolve",
+        "version": "1.1.7",
+        "source":
+          "archive:https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz#sha1:203114d82ad2c5ed9e8e0411b3932875e889e97b",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": []
+    },
+    "require-main-filename@1.0.1": {
+      "record": {
+        "name": "require-main-filename",
+        "version": "1.0.1",
+        "source":
+          "archive:https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz#sha1:97f717b69d48784f5f526a6c5aa8ffdda055a4d1",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": []
+    },
+    "require-directory@2.1.1": {
+      "record": {
+        "name": "require-directory",
+        "version": "2.1.1",
+        "source":
+          "archive:https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz#sha1:8c64ad5fd30dab1c976e2344ffe7f792a6a6df42",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": []
+    },
+    "request-promise-native@1.0.5": {
+      "record": {
+        "name": "request-promise-native",
+        "version": "1.0.5",
+        "source":
+          "archive:https://registry.npmjs.org/request-promise-native/-/request-promise-native-1.0.5.tgz#sha1:5281770f68e0c9719e5163fd3fab482215f4fda5",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [
+        "request-promise-core@1.1.1", "stealthy-require@1.1.1",
+        "tough-cookie@2.4.3"
+      ]
+    },
+    "request-promise-core@1.1.1": {
+      "record": {
+        "name": "request-promise-core",
+        "version": "1.1.1",
+        "source":
+          "archive:https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.1.tgz#sha1:3eee00b2c5aa83239cfb04c5700da36f81cd08b6",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [ "lodash@4.17.11" ]
+    },
+    "request@2.88.0": {
+      "record": {
+        "name": "request",
+        "version": "2.88.0",
+        "source":
+          "archive:https://registry.npmjs.org/request/-/request-2.88.0.tgz#sha1:9c2fca4f7d35b592efe57c7f0a55e81052124fef",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [
+        "aws-sign2@0.7.0", "aws4@1.8.0", "caseless@0.12.0",
+        "combined-stream@1.0.7", "extend@3.0.2", "forever-agent@0.6.1",
+        "form-data@2.3.3", "har-validator@5.1.0", "http-signature@1.2.0",
+        "is-typedarray@1.0.0", "isstream@0.1.2", "json-stringify-safe@5.0.1",
+        "mime-types@2.1.21", "oauth-sign@0.9.0", "performance-now@2.1.0",
+        "qs@6.5.2", "safe-buffer@5.1.2", "tough-cookie@2.4.3",
+        "tunnel-agent@0.6.0", "uuid@3.3.2"
+      ]
+    },
+    "repeating@2.0.1": {
+      "record": {
+        "name": "repeating",
+        "version": "2.0.1",
+        "source":
+          "archive:https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz#sha1:5214c53a926d3552707527fbab415dbc08d06dda",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [ "is-finite@1.0.2" ]
+    },
+    "repeat-string@1.6.1": {
+      "record": {
+        "name": "repeat-string",
+        "version": "1.6.1",
+        "source":
+          "archive:https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz#sha1:8dcae470e1c88abc2d600fff4a776286da75e637",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": []
+    },
+    "repeat-element@1.1.3": {
+      "record": {
+        "name": "repeat-element",
+        "version": "1.1.3",
+        "source":
+          "archive:https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.3.tgz#sha1:782e0d825c0c5a3bb39731f84efee6b742e6b1ce",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": []
+    },
+    "remove-trailing-separator@1.1.0": {
+      "record": {
+        "name": "remove-trailing-separator",
+        "version": "1.1.0",
+        "source":
+          "archive:https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz#sha1:c24bce2a283adad5bc3f58e0d48249b92379d8ef",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": []
+    },
+    "regex-not@1.0.2": {
+      "record": {
+        "name": "regex-not",
+        "version": "1.0.2",
+        "source":
+          "archive:https://registry.npmjs.org/regex-not/-/regex-not-1.0.2.tgz#sha1:1f4ece27e00b0b65e0247a6810e6a85d83a5752c",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [ "extend-shallow@3.0.2", "safe-regex@1.1.0" ]
+    },
+    "regex-cache@0.4.4": {
+      "record": {
+        "name": "regex-cache",
+        "version": "0.4.4",
+        "source":
+          "archive:https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.4.tgz#sha1:75bdc58a2a1496cec48a12835bc54c8d562336dd",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [ "is-equal-shallow@0.1.3" ]
+    },
+    "regenerator-runtime@0.11.1": {
+      "record": {
+        "name": "regenerator-runtime",
+        "version": "0.11.1",
+        "source":
+          "archive:https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz#sha1:be05ad7f9bf7d22e056f9726cee5017fbf19e2e9",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": []
+    },
+    "realpath-native@1.0.2": {
+      "record": {
+        "name": "realpath-native",
+        "version": "1.0.2",
+        "source":
+          "archive:https://registry.npmjs.org/realpath-native/-/realpath-native-1.0.2.tgz#sha1:cd51ce089b513b45cf9b1516c82989b51ccc6560",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [ "util.promisify@1.0.0" ]
+    },
+    "readable-stream@2.3.6": {
+      "record": {
+        "name": "readable-stream",
+        "version": "2.3.6",
+        "source":
+          "archive:http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz#sha1:b11c27d88b8ff1fbe070643cf94b0c79ae1b0aaf",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [
+        "core-util-is@1.0.2", "inherits@2.0.3", "isarray@1.0.0",
+        "process-nextick-args@2.0.0", "safe-buffer@5.1.2",
+        "string_decoder@1.1.1", "util-deprecate@1.0.2"
+      ]
+    },
+    "read-pkg-up@1.0.1": {
+      "record": {
+        "name": "read-pkg-up",
+        "version": "1.0.1",
+        "source":
+          "archive:https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz#sha1:9d63c13276c065918d57f002a57f40a1b643fb02",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [ "find-up@1.1.2", "read-pkg@1.1.0" ]
+    },
+    "read-pkg@1.1.0": {
+      "record": {
+        "name": "read-pkg",
+        "version": "1.1.0",
+        "source":
+          "archive:https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz#sha1:f5ffaa5ecd29cb31c0474bca7d756b6bb29e3f28",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [
+        "load-json-file@1.1.0", "normalize-package-data@2.4.0",
+        "path-type@1.1.0"
+      ]
+    },
+    "rc@1.2.8": {
+      "record": {
+        "name": "rc",
+        "version": "1.2.8",
+        "source":
+          "archive:https://registry.npmjs.org/rc/-/rc-1.2.8.tgz#sha1:cd924bf5200a075b83c188cd6b9e211b7fc0d3ed",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [
+        "deep-extend@0.6.0", "ini@1.3.5", "minimist@1.2.0",
+        "strip-json-comments@2.0.1"
+      ]
+    },
+    "randomatic@3.1.0": {
+      "record": {
+        "name": "randomatic",
+        "version": "3.1.0",
+        "source":
+          "archive:https://registry.npmjs.org/randomatic/-/randomatic-3.1.0.tgz#sha1:36f2ca708e9e567f5ed2ec01949026d50aa10116",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [
+        "is-number@4.0.0", "kind-of@6.0.2", "math-random@1.0.1"
+      ]
+    },
+    "query-string@5.1.1": {
+      "record": {
+        "name": "query-string",
+        "version": "5.1.1",
+        "source":
+          "archive:http://registry.npmjs.org/query-string/-/query-string-5.1.1.tgz#sha1:a78c012b71c17e05f2e3fa2319dd330682efb3cb",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [
+        "decode-uri-component@0.2.0", "object-assign@4.1.1",
+        "strict-uri-encode@1.1.0"
+      ]
+    },
+    "qs@6.5.2": {
+      "record": {
+        "name": "qs",
+        "version": "6.5.2",
+        "source":
+          "archive:https://registry.npmjs.org/qs/-/qs-6.5.2.tgz#sha1:cb3ae806e8740444584ef154ce8ee98d403f3e36",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": []
+    },
+    "punycode@2.1.1": {
+      "record": {
+        "name": "punycode",
+        "version": "2.1.1",
+        "source":
+          "archive:https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz#sha1:b58b010ac40c22c5657616c8d2c2c02c7bf479ec",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": []
+    },
+    "punycode@1.4.1": {
+      "record": {
+        "name": "punycode",
+        "version": "1.4.1",
+        "source":
+          "archive:https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz#sha1:c0d5a63b2718800ad8e1eb0fa5269c84dd41845e",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": []
+    },
+    "psl@1.1.29": {
+      "record": {
+        "name": "psl",
+        "version": "1.1.29",
+        "source":
+          "archive:https://registry.npmjs.org/psl/-/psl-1.1.29.tgz#sha1:60f580d360170bb722a797cc704411e6da850c67",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": []
+    },
+    "pseudomap@1.0.2": {
+      "record": {
+        "name": "pseudomap",
+        "version": "1.0.2",
+        "source":
+          "archive:https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz#sha1:f052a28da70e618917ef0a8ac34c1ae5a68286b3",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": []
+    },
+    "proto-list@1.2.4": {
+      "record": {
+        "name": "proto-list",
+        "version": "1.2.4",
+        "source":
+          "archive:https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz#sha1:212d5bfe1318306a420f6402b8e26ff39647a849",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": []
+    },
+    "prompts@0.1.14": {
+      "record": {
+        "name": "prompts",
+        "version": "0.1.14",
+        "source":
+          "archive:https://registry.npmjs.org/prompts/-/prompts-0.1.14.tgz#sha1:a8e15c612c5c9ec8f8111847df3337c9cbd443b2",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [ "kleur@2.0.2", "sisteransi@0.1.1" ]
+    },
+    "process-nextick-args@2.0.0": {
+      "record": {
+        "name": "process-nextick-args",
+        "version": "2.0.0",
+        "source":
+          "archive:https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz#sha1:a37d732f4271b4ab1ad070d35508e8290788ffaa",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": []
+    },
+    "private@0.1.8": {
+      "record": {
+        "name": "private",
+        "version": "0.1.8",
+        "source":
+          "archive:https://registry.npmjs.org/private/-/private-0.1.8.tgz#sha1:2381edb3689f7a53d653190060fcf822d2f368ff",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": []
+    },
+    "pretty-format@23.6.0": {
+      "record": {
+        "name": "pretty-format",
+        "version": "23.6.0",
+        "source":
+          "archive:https://registry.npmjs.org/pretty-format/-/pretty-format-23.6.0.tgz#sha1:5eaac8eeb6b33b987b7fe6097ea6a8a146ab5760",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [ "ansi-regex@3.0.0", "ansi-styles@3.2.1" ]
+    },
+    "preserve@0.2.0": {
+      "record": {
+        "name": "preserve",
+        "version": "0.2.0",
+        "source":
+          "archive:https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz#sha1:815ed1f6ebc65926f865b310c0713bcb3315ce4b",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": []
+    },
+    "prepend-http@2.0.0": {
+      "record": {
+        "name": "prepend-http",
+        "version": "2.0.0",
+        "source":
+          "archive:https://registry.npmjs.org/prepend-http/-/prepend-http-2.0.0.tgz#sha1:e92434bfa5ea8c19f41cdfd401d741a3c819d897",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": []
+    },
+    "prelude-ls@1.1.2": {
+      "record": {
+        "name": "prelude-ls",
+        "version": "1.1.2",
+        "source":
+          "archive:https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz#sha1:21932a549f5e52ffd9a827f570e04be62a97da54",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": []
+    },
+    "posix-character-classes@0.1.1": {
+      "record": {
+        "name": "posix-character-classes",
+        "version": "0.1.1",
+        "source":
+          "archive:https://registry.npmjs.org/posix-character-classes/-/posix-character-classes-0.1.1.tgz#sha1:01eac0fe3b5af71a2a6c02feabb8c1fef7e00eab",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": []
+    },
+    "pn@1.1.0": {
+      "record": {
+        "name": "pn",
+        "version": "1.1.0",
+        "source":
+          "archive:https://registry.npmjs.org/pn/-/pn-1.1.0.tgz#sha1:e2f4cef0e219f463c179ab37463e4e1ecdccbafb",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": []
+    },
+    "pkg-dir@2.0.0": {
+      "record": {
+        "name": "pkg-dir",
+        "version": "2.0.0",
+        "source":
+          "archive:https://registry.npmjs.org/pkg-dir/-/pkg-dir-2.0.0.tgz#sha1:f6d5d1109e19d63edf428e0bd57e12777615334b",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [ "find-up@2.1.0" ]
+    },
+    "pinkie-promise@2.0.1": {
+      "record": {
+        "name": "pinkie-promise",
+        "version": "2.0.1",
+        "source":
+          "archive:https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz#sha1:2135d6dfa7a358c069ac9b178776288228450ffa",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [ "pinkie@2.0.4" ]
+    },
+    "pinkie@2.0.4": {
+      "record": {
+        "name": "pinkie",
+        "version": "2.0.4",
+        "source":
+          "archive:https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz#sha1:72556b80cfa0d48a974e80e77248e80ed4f7f870",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": []
+    },
+    "pify@3.0.0": {
+      "record": {
+        "name": "pify",
+        "version": "3.0.0",
+        "source":
+          "archive:https://registry.npmjs.org/pify/-/pify-3.0.0.tgz#sha1:e5a4acd2c101fdf3d9a4d07f0dbc4db49dd28176",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": []
+    },
+    "pify@2.3.0": {
+      "record": {
+        "name": "pify",
+        "version": "2.3.0",
+        "source":
+          "archive:http://registry.npmjs.org/pify/-/pify-2.3.0.tgz#sha1:ed141a6ac043a849ea588498e7dca8b15330e90c",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": []
+    },
+    "performance-now@2.1.0": {
+      "record": {
+        "name": "performance-now",
+        "version": "2.1.0",
+        "source":
+          "archive:https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz#sha1:6309f4e0e5fa913ec1c69307ae364b4b377c9e7b",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": []
+    },
+    "pend@1.2.0": {
+      "record": {
+        "name": "pend",
+        "version": "1.2.0",
+        "source":
+          "archive:https://registry.npmjs.org/pend/-/pend-1.2.0.tgz#sha1:7a57eb550a6783f9115331fcf4663d5c8e007a50",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": []
+    },
+    "path-type@1.1.0": {
+      "record": {
+        "name": "path-type",
+        "version": "1.1.0",
+        "source":
+          "archive:https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz#sha1:59c44f7ee491da704da415da5a4070ba4f8fe441",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [
+        "graceful-fs@4.1.11", "pify@2.3.0", "pinkie-promise@2.0.1"
+      ]
+    },
+    "path-parse@1.0.6": {
+      "record": {
+        "name": "path-parse",
+        "version": "1.0.6",
+        "source":
+          "archive:https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz#sha1:d62dbb5679405d72c4737ec58600e9ddcf06d24c",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": []
+    },
+    "path-key@2.0.1": {
+      "record": {
+        "name": "path-key",
+        "version": "2.0.1",
+        "source":
+          "archive:https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz#sha1:411cadb574c5a140d3a4b1910d40d80cc9f40b40",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": []
+    },
+    "path-is-absolute@1.0.1": {
+      "record": {
+        "name": "path-is-absolute",
+        "version": "1.0.1",
+        "source":
+          "archive:https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz#sha1:174b9268735534ffbc7ace6bf53a5a9e1b5c5f5f",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": []
+    },
+    "path-exists@3.0.0": {
+      "record": {
+        "name": "path-exists",
+        "version": "3.0.0",
+        "source":
+          "archive:https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz#sha1:ce0ebeaa5f78cb18925ea7d810d7b59b010fd515",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": []
+    },
+    "path-exists@2.1.0": {
+      "record": {
+        "name": "path-exists",
+        "version": "2.1.0",
+        "source":
+          "archive:https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz#sha1:0feb6c64f0fc518d9a754dd5efb62c7022761f4b",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [ "pinkie-promise@2.0.1" ]
+    },
+    "pascalcase@0.1.1": {
+      "record": {
+        "name": "pascalcase",
+        "version": "0.1.1",
+        "source":
+          "archive:https://registry.npmjs.org/pascalcase/-/pascalcase-0.1.1.tgz#sha1:b363e55e8006ca6fe21784d2db22bd15d7917f14",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": []
+    },
+    "parse5@4.0.0": {
+      "record": {
+        "name": "parse5",
+        "version": "4.0.0",
+        "source":
+          "archive:https://registry.npmjs.org/parse5/-/parse5-4.0.0.tgz#sha1:6d78656e3da8d78b4ec0b906f7c08ef1dfe3f608",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": []
+    },
+    "parse-json@2.2.0": {
+      "record": {
+        "name": "parse-json",
+        "version": "2.2.0",
+        "source":
+          "archive:https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz#sha1:f480f40434ef80741f8469099f8dea18f55a4dc9",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [ "error-ex@1.3.2" ]
+    },
+    "parse-glob@3.0.4": {
+      "record": {
+        "name": "parse-glob",
+        "version": "3.0.4",
+        "source":
+          "archive:https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz#sha1:b2c376cfb11f35513badd173ef0bb6e3a388391c",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [
+        "glob-base@0.3.0", "is-dotfile@1.0.3", "is-extglob@1.0.0",
+        "is-glob@2.0.1"
+      ]
+    },
+    "p-try@1.0.0": {
+      "record": {
+        "name": "p-try",
+        "version": "1.0.0",
+        "source":
+          "archive:https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz#sha1:cbc79cdbaf8fd4228e13f621f2b1a237c1b207b3",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": []
+    },
+    "p-timeout@2.0.1": {
+      "record": {
+        "name": "p-timeout",
+        "version": "2.0.1",
+        "source":
+          "archive:https://registry.npmjs.org/p-timeout/-/p-timeout-2.0.1.tgz#sha1:d8dd1979595d2dc0139e1fe46b8b646cb3cdf038",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [ "p-finally@1.0.0" ]
+    },
+    "p-locate@2.0.0": {
+      "record": {
+        "name": "p-locate",
+        "version": "2.0.0",
+        "source":
+          "archive:https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz#sha1:20a0103b222a70c8fd39cc2e580680f3dde5ec43",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [ "p-limit@1.3.0" ]
+    },
+    "p-limit@1.3.0": {
+      "record": {
+        "name": "p-limit",
+        "version": "1.3.0",
+        "source":
+          "archive:https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz#sha1:b86bd5f0c25690911c7590fcbfc2010d54b3ccb8",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [ "p-try@1.0.0" ]
+    },
+    "p-is-promise@1.1.0": {
+      "record": {
+        "name": "p-is-promise",
+        "version": "1.1.0",
+        "source":
+          "archive:http://registry.npmjs.org/p-is-promise/-/p-is-promise-1.1.0.tgz#sha1:9c9456989e9f6588017b0434d56097675c3da05e",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": []
+    },
+    "p-finally@1.0.0": {
+      "record": {
+        "name": "p-finally",
+        "version": "1.0.0",
+        "source":
+          "archive:https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz#sha1:3fbcfb15b899a44123b34b6dcc18b724336a2cae",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": []
+    },
+    "p-event@2.1.0": {
+      "record": {
+        "name": "p-event",
+        "version": "2.1.0",
+        "source":
+          "archive:https://registry.npmjs.org/p-event/-/p-event-2.1.0.tgz#sha1:74de477a4e6b3aa8267240c7099e78ac52cb4db4",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [ "p-timeout@2.0.1" ]
+    },
+    "p-cancelable@0.4.1": {
+      "record": {
+        "name": "p-cancelable",
+        "version": "0.4.1",
+        "source":
+          "archive:http://registry.npmjs.org/p-cancelable/-/p-cancelable-0.4.1.tgz#sha1:35f363d67d52081c8d9585e37bcceb7e0bbcb2a0",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": []
+    },
+    "osenv@0.1.5": {
+      "record": {
+        "name": "osenv",
+        "version": "0.1.5",
+        "source":
+          "archive:https://registry.npmjs.org/osenv/-/osenv-0.1.5.tgz#sha1:85cdfafaeb28e8677f416e287592b5f3f49ea410",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [ "os-homedir@1.0.2", "os-tmpdir@1.0.2" ]
+    },
+    "os-tmpdir@1.0.2": {
+      "record": {
+        "name": "os-tmpdir",
+        "version": "1.0.2",
+        "source":
+          "archive:https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz#sha1:bbe67406c79aa85c5cfec766fe5734555dfa1274",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": []
+    },
+    "os-locale@2.1.0": {
+      "record": {
+        "name": "os-locale",
+        "version": "2.1.0",
+        "source":
+          "archive:https://registry.npmjs.org/os-locale/-/os-locale-2.1.0.tgz#sha1:42bc2900a6b5b8bd17376c8e882b65afccf24bf2",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [ "execa@0.7.0", "lcid@1.0.0", "mem@1.1.0" ]
+    },
+    "os-homedir@1.0.2": {
+      "record": {
+        "name": "os-homedir",
+        "version": "1.0.2",
+        "source":
+          "archive:https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz#sha1:ffbc4988336e0e833de0c168c7ef152121aa7fb3",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": []
+    },
+    "optionator@0.8.2": {
+      "record": {
+        "name": "optionator",
+        "version": "0.8.2",
+        "source":
+          "archive:https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz#sha1:364c5e409d3f4d6301d6c0b4c05bba50180aeb64",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [
+        "deep-is@0.1.3", "fast-levenshtein@2.0.6", "levn@0.3.0",
+        "prelude-ls@1.1.2", "type-check@0.3.2", "wordwrap@1.0.0"
+      ]
+    },
+    "optimist@0.6.1": {
+      "record": {
+        "name": "optimist",
+        "version": "0.6.1",
+        "source":
+          "archive:https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz#sha1:da3ea74686fa21a19a111c326e90eb15a0196686",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [ "minimist@0.0.10", "wordwrap@0.0.3" ]
+    },
+    "once@1.4.0": {
+      "record": {
+        "name": "once",
+        "version": "1.4.0",
+        "source":
+          "archive:https://registry.npmjs.org/once/-/once-1.4.0.tgz#sha1:583b1aa775961d4b113ac17d9c50baef9dd76bd1",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [ "wrappy@1.0.2" ]
+    },
+    "object.pick@1.3.0": {
+      "record": {
+        "name": "object.pick",
+        "version": "1.3.0",
+        "source":
+          "archive:https://registry.npmjs.org/object.pick/-/object.pick-1.3.0.tgz#sha1:87a10ac4c1694bd2e1cbf53591a66141fb5dd747",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [ "isobject@3.0.1" ]
+    },
+    "object.omit@2.0.1": {
+      "record": {
+        "name": "object.omit",
+        "version": "2.0.1",
+        "source":
+          "archive:https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz#sha1:1a9c744829f39dbb858c76ca3579ae2a54ebd1fa",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [ "for-own@0.1.5", "is-extendable@0.1.1" ]
+    },
+    "object.getownpropertydescriptors@2.0.3": {
+      "record": {
+        "name": "object.getownpropertydescriptors",
+        "version": "2.0.3",
+        "source":
+          "archive:https://registry.npmjs.org/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.0.3.tgz#sha1:8758c846f5b407adab0f236e0986f14b051caa16",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [ "define-properties@1.1.3", "es-abstract@1.12.0" ]
+    },
+    "object-visit@1.0.1": {
+      "record": {
+        "name": "object-visit",
+        "version": "1.0.1",
+        "source":
+          "archive:https://registry.npmjs.org/object-visit/-/object-visit-1.0.1.tgz#sha1:f79c4493af0c5377b59fe39d395e41042dd045bb",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [ "isobject@3.0.1" ]
+    },
+    "object-keys@1.0.12": {
+      "record": {
+        "name": "object-keys",
+        "version": "1.0.12",
+        "source":
+          "archive:https://registry.npmjs.org/object-keys/-/object-keys-1.0.12.tgz#sha1:09c53855377575310cca62f55bb334abff7b3ed2",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": []
+    },
+    "object-copy@0.1.0": {
+      "record": {
+        "name": "object-copy",
+        "version": "0.1.0",
+        "source":
+          "archive:https://registry.npmjs.org/object-copy/-/object-copy-0.1.0.tgz#sha1:7e7d858b781bd7c991a41ba975ed3812754e998c",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [
+        "copy-descriptor@0.1.1", "define-property@0.2.5", "kind-of@3.2.2"
+      ]
+    },
+    "object-assign@4.1.1": {
+      "record": {
+        "name": "object-assign",
+        "version": "4.1.1",
+        "source":
+          "archive:https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz#sha1:2109adc7965887cfc05cbbd442cac8bfbb360863",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": []
+    },
+    "oauth-sign@0.9.0": {
+      "record": {
+        "name": "oauth-sign",
+        "version": "0.9.0",
+        "source":
+          "archive:https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz#sha1:47a7b016baa68b5fa0ecf3dee08a85c679ac6455",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": []
+    },
+    "nwsapi@2.0.9": {
+      "record": {
+        "name": "nwsapi",
+        "version": "2.0.9",
+        "source":
+          "archive:https://registry.npmjs.org/nwsapi/-/nwsapi-2.0.9.tgz#sha1:77ac0cdfdcad52b6a1151a84e73254edc33ed016",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": []
+    },
+    "number-is-nan@1.0.1": {
+      "record": {
+        "name": "number-is-nan",
+        "version": "1.0.1",
+        "source":
+          "archive:https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz#sha1:097b602b53422a522c1afb8790318336941a011d",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": []
+    },
+    "npmlog@4.1.2": {
+      "record": {
+        "name": "npmlog",
+        "version": "4.1.2",
+        "source":
+          "archive:https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz#sha1:08a7f2a8bf734604779a9efa4ad5cc717abb954b",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [
+        "are-we-there-yet@1.1.5", "console-control-strings@1.1.0",
+        "gauge@2.7.4", "set-blocking@2.0.0"
+      ]
+    },
+    "npm-run-path@2.0.2": {
+      "record": {
+        "name": "npm-run-path",
+        "version": "2.0.2",
+        "source":
+          "archive:https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz#sha1:35a9232dfa35d7067b4cb2ddf2357b1871536c5f",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [ "path-key@2.0.1" ]
+    },
+    "npm-packlist@1.1.12": {
+      "record": {
+        "name": "npm-packlist",
+        "version": "1.1.12",
+        "source":
+          "archive:https://registry.npmjs.org/npm-packlist/-/npm-packlist-1.1.12.tgz#sha1:22bde2ebc12e72ca482abd67afc51eb49377243a",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [ "ignore-walk@3.0.1", "npm-bundled@1.0.5" ]
+    },
+    "npm-conf@1.1.3": {
+      "record": {
+        "name": "npm-conf",
+        "version": "1.1.3",
+        "source":
+          "archive:https://registry.npmjs.org/npm-conf/-/npm-conf-1.1.3.tgz#sha1:256cc47bd0e218c259c4e9550bf413bc2192aff9",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [ "config-chain@1.1.12", "pify@3.0.0" ]
+    },
+    "npm-bundled@1.0.5": {
+      "record": {
+        "name": "npm-bundled",
+        "version": "1.0.5",
+        "source":
+          "archive:https://registry.npmjs.org/npm-bundled/-/npm-bundled-1.0.5.tgz#sha1:3c1732b7ba936b3a10325aef616467c0ccbcc979",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": []
+    },
+    "normalize-url@2.0.1": {
+      "record": {
+        "name": "normalize-url",
+        "version": "2.0.1",
+        "source":
+          "archive:https://registry.npmjs.org/normalize-url/-/normalize-url-2.0.1.tgz#sha1:835a9da1551fa26f70e92329069a23aa6574d7e6",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [
+        "prepend-http@2.0.0", "query-string@5.1.1", "sort-keys@2.0.0"
+      ]
+    },
+    "normalize-path@2.1.1": {
+      "record": {
+        "name": "normalize-path",
+        "version": "2.1.1",
+        "source":
+          "archive:https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz#sha1:1ab28b556e198363a8c1a6f7e6fa20137fe6aed9",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [ "remove-trailing-separator@1.1.0" ]
+    },
+    "normalize-package-data@2.4.0": {
+      "record": {
+        "name": "normalize-package-data",
+        "version": "2.4.0",
+        "source":
+          "archive:https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz#sha1:12f95a307d58352075a04907b84ac8be98ac012f",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [
+        "hosted-git-info@2.7.1", "is-builtin-module@1.0.0", "semver@5.6.0",
+        "validate-npm-package-license@3.0.4"
+      ]
+    },
+    "nopt@4.0.1": {
+      "record": {
+        "name": "nopt",
+        "version": "4.0.1",
+        "source":
+          "archive:https://registry.npmjs.org/nopt/-/nopt-4.0.1.tgz#sha1:d0d4685afd5415193c8c7505602d0d17cd64474d",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [ "abbrev@1.1.1", "osenv@0.1.5" ]
+    },
+    "node-pre-gyp@0.10.3": {
+      "record": {
+        "name": "node-pre-gyp",
+        "version": "0.10.3",
+        "source":
+          "archive:https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.10.3.tgz#sha1:3070040716afdc778747b61b6887bf78880b80fc",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [
+        "detect-libc@1.0.3", "mkdirp@0.5.1", "needle@2.2.4", "nopt@4.0.1",
+        "npm-packlist@1.1.12", "npmlog@4.1.2", "rc@1.2.8", "rimraf@2.6.2",
+        "semver@5.6.0", "tar@4.4.6"
+      ]
+    },
+    "node-notifier@5.3.0": {
+      "record": {
+        "name": "node-notifier",
+        "version": "5.3.0",
+        "source":
+          "archive:https://registry.npmjs.org/node-notifier/-/node-notifier-5.3.0.tgz#sha1:c77a4a7b84038733d5fb351aafd8a268bfe19a01",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [
+        "growly@1.3.0", "semver@5.6.0", "shellwords@0.1.1", "which@1.3.1"
+      ]
+    },
+    "node-int64@0.4.0": {
+      "record": {
+        "name": "node-int64",
+        "version": "0.4.0",
+        "source":
+          "archive:https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz#sha1:87a9065cdb355d3182d8f94ce11188b825c68a3b",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": []
+    },
+    "needle@2.2.4": {
+      "record": {
+        "name": "needle",
+        "version": "2.2.4",
+        "source":
+          "archive:https://registry.npmjs.org/needle/-/needle-2.2.4.tgz#sha1:51931bff82533b1928b7d1d69e01f1b00ffd2a4e",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [ "debug@2.6.9", "iconv-lite@0.4.24", "sax@1.2.4" ]
+    },
+    "natural-compare@1.4.0": {
+      "record": {
+        "name": "natural-compare",
+        "version": "1.4.0",
+        "source":
+          "archive:https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz#sha1:4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": []
+    },
+    "nanomatch@1.2.13": {
+      "record": {
+        "name": "nanomatch",
+        "version": "1.2.13",
+        "source":
+          "archive:https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.13.tgz#sha1:b87a8aa4fc0de8fe6be88895b38983ff265bd119",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [
+        "arr-diff@4.0.0", "array-unique@0.3.2", "define-property@2.0.2",
+        "extend-shallow@3.0.2", "fragment-cache@0.2.1", "is-windows@1.0.2",
+        "kind-of@6.0.2", "object.pick@1.3.0", "regex-not@1.0.2",
+        "snapdragon@0.8.2", "to-regex@3.0.2"
+      ]
+    },
+    "nan@2.11.1": {
+      "record": {
+        "name": "nan",
+        "version": "2.11.1",
+        "source":
+          "archive:https://registry.npmjs.org/nan/-/nan-2.11.1.tgz#sha1:90e22bccb8ca57ea4cd37cc83d3819b52eea6766",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": []
+    },
+    "ms@2.1.1": {
+      "record": {
+        "name": "ms",
+        "version": "2.1.1",
+        "source":
+          "archive:https://registry.npmjs.org/ms/-/ms-2.1.1.tgz#sha1:30a5864eb3ebb0a66f2ebe6d727af06a09d86e0a",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": []
+    },
+    "ms@2.0.0": {
+      "record": {
+        "name": "ms",
+        "version": "2.0.0",
+        "source":
+          "archive:https://registry.npmjs.org/ms/-/ms-2.0.0.tgz#sha1:5608aeadfc00be6c2901df5f9861788de0d597c8",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": []
+    },
+    "mkdirp@0.5.1": {
+      "record": {
+        "name": "mkdirp",
+        "version": "0.5.1",
+        "source":
+          "archive:http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz#sha1:30057438eac6cf7f8c4767f38648d6697d75c903",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [ "minimist@0.0.8" ]
+    },
+    "mixin-deep@1.3.1": {
+      "record": {
+        "name": "mixin-deep",
+        "version": "1.3.1",
+        "source":
+          "archive:https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.1.tgz#sha1:a49e7268dce1a0d9698e45326c5626df3543d0fe",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [ "for-in@1.0.2", "is-extendable@1.0.1" ]
+    },
+    "minizlib@1.1.1": {
+      "record": {
+        "name": "minizlib",
+        "version": "1.1.1",
+        "source":
+          "archive:https://registry.npmjs.org/minizlib/-/minizlib-1.1.1.tgz#sha1:6734acc045a46e61d596a43bb9d9cd326e19cc42",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [ "minipass@2.3.4" ]
+    },
+    "minipass@2.3.4": {
+      "record": {
+        "name": "minipass",
+        "version": "2.3.4",
+        "source":
+          "archive:https://registry.npmjs.org/minipass/-/minipass-2.3.4.tgz#sha1:4768d7605ed6194d6d576169b9e12ef71e9d9957",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [ "safe-buffer@5.1.2", "yallist@3.0.2" ]
+    },
+    "minimist@1.2.0": {
+      "record": {
+        "name": "minimist",
+        "version": "1.2.0",
+        "source":
+          "archive:http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz#sha1:a35008b20f41383eec1fb914f4cd5df79a264284",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": []
+    },
+    "minimist@0.0.10": {
+      "record": {
+        "name": "minimist",
+        "version": "0.0.10",
+        "source":
+          "archive:http://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz#sha1:de3f98543dbf96082be48ad1a0c7cda836301dcf",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": []
+    },
+    "minimist@0.0.8": {
+      "record": {
+        "name": "minimist",
+        "version": "0.0.8",
+        "source":
+          "archive:http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz#sha1:857fcabfc3397d2625b8228262e86aa7a011b05d",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": []
+    },
+    "minimatch@3.0.4": {
+      "record": {
+        "name": "minimatch",
+        "version": "3.0.4",
+        "source":
+          "archive:https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz#sha1:5166e286457f03306064be5497e8dbb0c3d32083",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [ "brace-expansion@1.1.11" ]
+    },
+    "mimic-response@1.0.1": {
+      "record": {
+        "name": "mimic-response",
+        "version": "1.0.1",
+        "source":
+          "archive:https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz#sha1:4923538878eef42063cb8a3e3b0798781487ab1b",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": []
+    },
+    "mimic-fn@1.2.0": {
+      "record": {
+        "name": "mimic-fn",
+        "version": "1.2.0",
+        "source":
+          "archive:https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz#sha1:820c86a39334640e99516928bd03fca88057d022",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": []
+    },
+    "mime-types@2.1.21": {
+      "record": {
+        "name": "mime-types",
+        "version": "2.1.21",
+        "source":
+          "archive:https://registry.npmjs.org/mime-types/-/mime-types-2.1.21.tgz#sha1:28995aa1ecb770742fe6ae7e58f9181c744b3f96",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [ "mime-db@1.37.0" ]
+    },
+    "mime-db@1.37.0": {
+      "record": {
+        "name": "mime-db",
+        "version": "1.37.0",
+        "source":
+          "archive:https://registry.npmjs.org/mime-db/-/mime-db-1.37.0.tgz#sha1:0b6a0ce6fdbe9576e25f1f2d2fde8830dc0ad0d8",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": []
+    },
+    "micromatch@3.1.10": {
+      "record": {
+        "name": "micromatch",
+        "version": "3.1.10",
+        "source":
+          "archive:https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz#sha1:70859bc95c9840952f359a068a3fc49f9ecfac23",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [
+        "arr-diff@4.0.0", "array-unique@0.3.2", "braces@2.3.2",
+        "define-property@2.0.2", "extend-shallow@3.0.2", "extglob@2.0.4",
+        "fragment-cache@0.2.1", "kind-of@6.0.2", "nanomatch@1.2.13",
+        "object.pick@1.3.0", "regex-not@1.0.2", "snapdragon@0.8.2",
+        "to-regex@3.0.2"
+      ]
+    },
+    "micromatch@2.3.11": {
+      "record": {
+        "name": "micromatch",
+        "version": "2.3.11",
+        "source":
+          "archive:https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz#sha1:86677c97d1720b363431d04d0d15293bd38c1565",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [
+        "arr-diff@2.0.0", "array-unique@0.2.1", "braces@1.8.5",
+        "expand-brackets@0.1.5", "extglob@0.3.2", "filename-regex@2.0.1",
+        "is-extglob@1.0.0", "is-glob@2.0.1", "kind-of@3.2.2",
+        "normalize-path@2.1.1", "object.omit@2.0.1", "parse-glob@3.0.4",
+        "regex-cache@0.4.4"
+      ]
+    },
+    "merge-stream@1.0.1": {
+      "record": {
+        "name": "merge-stream",
+        "version": "1.0.1",
+        "source":
+          "archive:https://registry.npmjs.org/merge-stream/-/merge-stream-1.0.1.tgz#sha1:4041202d508a342ba00174008df0c251b8c135e1",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [ "readable-stream@2.3.6" ]
+    },
+    "merge@1.2.0": {
+      "record": {
+        "name": "merge",
+        "version": "1.2.0",
+        "source":
+          "archive:https://registry.npmjs.org/merge/-/merge-1.2.0.tgz#sha1:7531e39d4949c281a66b8c5a6e0265e8b05894da",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": []
+    },
+    "mem@1.1.0": {
+      "record": {
+        "name": "mem",
+        "version": "1.1.0",
+        "source":
+          "archive:https://registry.npmjs.org/mem/-/mem-1.1.0.tgz#sha1:5edd52b485ca1d900fe64895505399a0dfa45f76",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [ "mimic-fn@1.2.0" ]
+    },
+    "math-random@1.0.1": {
+      "record": {
+        "name": "math-random",
+        "version": "1.0.1",
+        "source":
+          "archive:https://registry.npmjs.org/math-random/-/math-random-1.0.1.tgz#sha1:8b3aac588b8a66e4975e3cdea67f7bb329601fac",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": []
+    },
+    "map-visit@1.0.0": {
+      "record": {
+        "name": "map-visit",
+        "version": "1.0.0",
+        "source":
+          "archive:https://registry.npmjs.org/map-visit/-/map-visit-1.0.0.tgz#sha1:ecdca8f13144e660f1b5bd41f12f3479d98dfb8f",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [ "object-visit@1.0.1" ]
+    },
+    "map-cache@0.2.2": {
+      "record": {
+        "name": "map-cache",
+        "version": "0.2.2",
+        "source":
+          "archive:https://registry.npmjs.org/map-cache/-/map-cache-0.2.2.tgz#sha1:c32abd0bd6525d9b051645bb4f26ac5dc98a0dbf",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": []
+    },
+    "makeerror@1.0.11": {
+      "record": {
+        "name": "makeerror",
+        "version": "1.0.11",
+        "source":
+          "archive:https://registry.npmjs.org/makeerror/-/makeerror-1.0.11.tgz#sha1:e01a5c9109f2af79660e4e8b9587790184f5a96c",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [ "tmpl@1.0.4" ]
+    },
+    "make-dir@1.3.0": {
+      "record": {
+        "name": "make-dir",
+        "version": "1.3.0",
+        "source":
+          "archive:https://registry.npmjs.org/make-dir/-/make-dir-1.3.0.tgz#sha1:79c1033b80515bd6d24ec9933e860ca75ee27f0c",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [ "pify@3.0.0" ]
+    },
+    "lru-cache@4.1.3": {
+      "record": {
+        "name": "lru-cache",
+        "version": "4.1.3",
+        "source":
+          "archive:https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.3.tgz#sha1:a1175cf3496dfc8436c156c334b4955992bce69c",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [ "pseudomap@1.0.2", "yallist@2.1.2" ]
+    },
+    "lowercase-keys@1.0.1": {
+      "record": {
+        "name": "lowercase-keys",
+        "version": "1.0.1",
+        "source":
+          "archive:https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.1.tgz#sha1:6f9e30b47084d971a7c820ff15a6c5167b74c26f",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": []
+    },
+    "lowercase-keys@1.0.0": {
+      "record": {
+        "name": "lowercase-keys",
+        "version": "1.0.0",
+        "source":
+          "archive:https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.0.tgz#sha1:4e3366b39e7f5457e35f1324bdf6f88d0bfc7306",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": []
+    },
+    "loose-envify@1.4.0": {
+      "record": {
+        "name": "loose-envify",
+        "version": "1.4.0",
+        "source":
+          "archive:https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz#sha1:71ee51fa7be4caec1a63839f7e682d8132d30caf",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [ "js-tokens@3.0.2" ]
+    },
+    "lodash.sortby@4.7.0": {
+      "record": {
+        "name": "lodash.sortby",
+        "version": "4.7.0",
+        "source":
+          "archive:https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz#sha1:edd14c824e2cc9c1e0b0a1b42bb5210516a42438",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": []
+    },
+    "lodash@4.17.11": {
+      "record": {
+        "name": "lodash",
+        "version": "4.17.11",
+        "source":
+          "archive:https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz#sha1:b39ea6229ef607ecd89e2c8df12536891cac9b8d",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": []
+    },
+    "locate-path@2.0.0": {
+      "record": {
+        "name": "locate-path",
+        "version": "2.0.0",
+        "source":
+          "archive:https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz#sha1:2b568b265eec944c6d9c0de9c3dbbbca0354cd8e",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [ "p-locate@2.0.0", "path-exists@3.0.0" ]
+    },
+    "load-json-file@1.1.0": {
+      "record": {
+        "name": "load-json-file",
+        "version": "1.1.0",
+        "source":
+          "archive:http://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz#sha1:956905708d58b4bab4c2261b04f59f31c99374c0",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [
+        "graceful-fs@4.1.11", "parse-json@2.2.0", "pify@2.3.0",
+        "pinkie-promise@2.0.1", "strip-bom@2.0.0"
+      ]
+    },
+    "levn@0.3.0": {
+      "record": {
+        "name": "levn",
+        "version": "0.3.0",
+        "source":
+          "archive:https://registry.npmjs.org/levn/-/levn-0.3.0.tgz#sha1:3b09924edf9f083c0490fdd4c0bc4421e04764ee",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [ "prelude-ls@1.1.2", "type-check@0.3.2" ]
+    },
+    "leven@2.1.0": {
+      "record": {
+        "name": "leven",
+        "version": "2.1.0",
+        "source":
+          "archive:https://registry.npmjs.org/leven/-/leven-2.1.0.tgz#sha1:c2e7a9f772094dee9d34202ae8acce4687875580",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": []
+    },
+    "left-pad@1.3.0": {
+      "record": {
+        "name": "left-pad",
+        "version": "1.3.0",
+        "source":
+          "archive:https://registry.npmjs.org/left-pad/-/left-pad-1.3.0.tgz#sha1:5b8a3a7765dfe001261dde915589e782f8c94d1e",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": []
+    },
+    "lcid@1.0.0": {
+      "record": {
+        "name": "lcid",
+        "version": "1.0.0",
+        "source":
+          "archive:https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz#sha1:308accafa0bc483a3867b4b6f2b9506251d1b835",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [ "invert-kv@1.0.0" ]
+    },
+    "kleur@2.0.2": {
+      "record": {
+        "name": "kleur",
+        "version": "2.0.2",
+        "source":
+          "archive:https://registry.npmjs.org/kleur/-/kleur-2.0.2.tgz#sha1:b704f4944d95e255d038f0cb05fb8a602c55a300",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": []
+    },
+    "kind-of@6.0.2": {
+      "record": {
+        "name": "kind-of",
+        "version": "6.0.2",
+        "source":
+          "archive:https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz#sha1:01146b36a6218e64e58f3a8d66de5d7fc6f6d051",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": []
+    },
+    "kind-of@5.1.0": {
+      "record": {
+        "name": "kind-of",
+        "version": "5.1.0",
+        "source":
+          "archive:https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz#sha1:729c91e2d857b7a419a1f9aa65685c4c33f5845d",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": []
+    },
+    "kind-of@4.0.0": {
+      "record": {
+        "name": "kind-of",
+        "version": "4.0.0",
+        "source":
+          "archive:https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz#sha1:20813df3d712928b207378691a45066fae72dd57",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [ "is-buffer@1.1.6" ]
+    },
+    "kind-of@3.2.2": {
+      "record": {
+        "name": "kind-of",
+        "version": "3.2.2",
+        "source":
+          "archive:https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz#sha1:31ea21a734bab9bbb0f32466d893aea51e4a3c64",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [ "is-buffer@1.1.6" ]
+    },
+    "keyv@3.0.0": {
+      "record": {
+        "name": "keyv",
+        "version": "3.0.0",
+        "source":
+          "archive:https://registry.npmjs.org/keyv/-/keyv-3.0.0.tgz#sha1:44923ba39e68b12a7cec7df6c3268c031f2ef373",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [ "json-buffer@3.0.0" ]
+    },
+    "jsprim@1.4.1": {
+      "record": {
+        "name": "jsprim",
+        "version": "1.4.1",
+        "source":
+          "archive:https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz#sha1:313e66bc1e5cc06e438bc1b7499c2e5c56acb6a2",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [
+        "assert-plus@1.0.0", "extsprintf@1.3.0", "json-schema@0.2.3",
+        "verror@1.10.0"
+      ]
+    },
+    "json5@0.5.1": {
+      "record": {
+        "name": "json5",
+        "version": "0.5.1",
+        "source":
+          "archive:http://registry.npmjs.org/json5/-/json5-0.5.1.tgz#sha1:1eade7acc012034ad84e2396767ead9fa5495821",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": []
+    },
+    "json-stringify-safe@5.0.1": {
+      "record": {
+        "name": "json-stringify-safe",
+        "version": "5.0.1",
+        "source":
+          "archive:https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz#sha1:1296a2d58fd45f19a0f6ce01d65701e2c735b6eb",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": []
+    },
+    "json-schema-traverse@0.3.1": {
+      "record": {
+        "name": "json-schema-traverse",
+        "version": "0.3.1",
+        "source":
+          "archive:https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz#sha1:349a6d44c53a51de89b40805c5d5e59b417d3340",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": []
+    },
+    "json-schema@0.2.3": {
+      "record": {
+        "name": "json-schema",
+        "version": "0.2.3",
+        "source":
+          "archive:https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz#sha1:b480c892e59a2f05954ce727bd3f2a4e882f9e13",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": []
+    },
+    "json-buffer@3.0.0": {
+      "record": {
+        "name": "json-buffer",
+        "version": "3.0.0",
+        "source":
+          "archive:https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.0.tgz#sha1:5b1f397afc75d677bde8bcfc0e47e1f9a3d9a898",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": []
+    },
+    "jsesc@1.3.0": {
+      "record": {
+        "name": "jsesc",
+        "version": "1.3.0",
+        "source":
+          "archive:https://registry.npmjs.org/jsesc/-/jsesc-1.3.0.tgz#sha1:46c3fec8c1892b12b0833db9bc7622176dbab34b",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": []
+    },
+    "jsdom@11.12.0": {
+      "record": {
+        "name": "jsdom",
+        "version": "11.12.0",
+        "source":
+          "archive:https://registry.npmjs.org/jsdom/-/jsdom-11.12.0.tgz#sha1:1a80d40ddd378a1de59656e9e6dc5a3ba8657bc8",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [
+        "abab@2.0.0", "acorn@5.7.3", "acorn-globals@4.3.0",
+        "array-equal@1.0.0", "cssom@0.3.4", "cssstyle@1.1.1",
+        "data-urls@1.0.1", "domexception@1.0.1", "escodegen@1.11.0",
+        "html-encoding-sniffer@1.0.2", "left-pad@1.3.0", "nwsapi@2.0.9",
+        "parse5@4.0.0", "pn@1.1.0", "request@2.88.0",
+        "request-promise-native@1.0.5", "sax@1.2.4", "symbol-tree@3.2.2",
+        "tough-cookie@2.4.3", "w3c-hr-time@1.0.1",
+        "webidl-conversions@4.0.2", "whatwg-encoding@1.0.5",
+        "whatwg-mimetype@2.2.0", "whatwg-url@6.5.0", "ws@5.2.2",
+        "xml-name-validator@3.0.0"
+      ]
+    },
+    "jsbn@0.1.1": {
+      "record": {
+        "name": "jsbn",
+        "version": "0.1.1",
+        "source":
+          "archive:https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz#sha1:a5e654c2e5a2deb5f201d96cefbca80c0ef2f513",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": []
+    },
+    "js-yaml@3.12.0": {
+      "record": {
+        "name": "js-yaml",
+        "version": "3.12.0",
+        "source":
+          "archive:https://registry.npmjs.org/js-yaml/-/js-yaml-3.12.0.tgz#sha1:eaed656ec8344f10f527c6bfa1b6e2244de167d1",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [ "argparse@1.0.10", "esprima@4.0.1" ]
+    },
+    "js-tokens@4.0.0": {
+      "record": {
+        "name": "js-tokens",
+        "version": "4.0.0",
+        "source":
+          "archive:https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz#sha1:19203fb59991df98e3a287050d4647cdeaf32499",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": []
+    },
+    "js-tokens@3.0.2": {
+      "record": {
+        "name": "js-tokens",
+        "version": "3.0.2",
+        "source":
+          "archive:https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz#sha1:9866df395102130e38f7f996bceb65443209c25b",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": []
+    },
+    "jest-worker@23.2.0": {
+      "record": {
+        "name": "jest-worker",
+        "version": "23.2.0",
+        "source":
+          "archive:https://registry.npmjs.org/jest-worker/-/jest-worker-23.2.0.tgz#sha1:faf706a8da36fae60eb26957257fa7b5d8ea02b9",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [ "merge-stream@1.0.1" ]
+    },
+    "jest-watcher@23.4.0": {
+      "record": {
+        "name": "jest-watcher",
+        "version": "23.4.0",
+        "source":
+          "archive:https://registry.npmjs.org/jest-watcher/-/jest-watcher-23.4.0.tgz#sha1:d2e28ce74f8dad6c6afc922b92cabef6ed05c91c",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [
+        "ansi-escapes@3.1.0", "chalk@2.4.1", "string-length@2.0.0"
+      ]
+    },
+    "jest-validate@23.6.0": {
+      "record": {
+        "name": "jest-validate",
+        "version": "23.6.0",
+        "source":
+          "archive:https://registry.npmjs.org/jest-validate/-/jest-validate-23.6.0.tgz#sha1:36761f99d1ed33fcd425b4e4c5595d62b6597474",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [
+        "chalk@2.4.1", "jest-get-type@22.4.3", "leven@2.1.0",
+        "pretty-format@23.6.0"
+      ]
+    },
+    "jest-util@23.4.0": {
+      "record": {
+        "name": "jest-util",
+        "version": "23.4.0",
+        "source":
+          "archive:https://registry.npmjs.org/jest-util/-/jest-util-23.4.0.tgz#sha1:4d063cb927baf0a23831ff61bec2cbbf49793561",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [
+        "callsites@2.0.0", "chalk@2.4.1", "graceful-fs@4.1.11",
+        "is-ci@1.2.1", "jest-message-util@23.4.0", "mkdirp@0.5.1",
+        "slash@1.0.0", "source-map@0.6.1"
+      ]
+    },
+    "jest-snapshot@23.6.0": {
+      "record": {
+        "name": "jest-snapshot",
+        "version": "23.6.0",
+        "source":
+          "archive:https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-23.6.0.tgz#sha1:f9c2625d1b18acda01ec2d2b826c0ce58a5aa17a",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [
+        "babel-types@6.26.0", "chalk@2.4.1", "jest-diff@23.6.0",
+        "jest-matcher-utils@23.6.0", "jest-message-util@23.4.0",
+        "jest-resolve@23.6.0", "mkdirp@0.5.1", "natural-compare@1.4.0",
+        "pretty-format@23.6.0", "semver@5.6.0"
+      ]
+    },
+    "jest-serializer@23.0.1": {
+      "record": {
+        "name": "jest-serializer",
+        "version": "23.0.1",
+        "source":
+          "archive:https://registry.npmjs.org/jest-serializer/-/jest-serializer-23.0.1.tgz#sha1:a3776aeb311e90fe83fab9e533e85102bd164165",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": []
+    },
+    "jest-runtime@23.6.0": {
+      "record": {
+        "name": "jest-runtime",
+        "version": "23.6.0",
+        "source":
+          "archive:https://registry.npmjs.org/jest-runtime/-/jest-runtime-23.6.0.tgz#sha1:059e58c8ab445917cd0e0d84ac2ba68de8f23082",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [
+        "babel-core@6.26.3", "babel-plugin-istanbul@4.1.6", "chalk@2.4.1",
+        "convert-source-map@1.6.0", "exit@0.1.2",
+        "fast-json-stable-stringify@2.0.0", "graceful-fs@4.1.11",
+        "jest-config@23.6.0", "jest-haste-map@23.6.0",
+        "jest-message-util@23.4.0", "jest-regex-util@23.3.0",
+        "jest-resolve@23.6.0", "jest-snapshot@23.6.0", "jest-util@23.4.0",
+        "jest-validate@23.6.0", "micromatch@2.3.11", "realpath-native@1.0.2",
+        "slash@1.0.0", "strip-bom@3.0.0", "write-file-atomic@2.3.0",
+        "yargs@11.1.0"
+      ]
+    },
+    "jest-runner@23.6.0": {
+      "record": {
+        "name": "jest-runner",
+        "version": "23.6.0",
+        "source":
+          "archive:https://registry.npmjs.org/jest-runner/-/jest-runner-23.6.0.tgz#sha1:3894bd219ffc3f3cb94dc48a4170a2e6f23a5a38",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [
+        "exit@0.1.2", "graceful-fs@4.1.11", "jest-config@23.6.0",
+        "jest-docblock@23.2.0", "jest-haste-map@23.6.0",
+        "jest-jasmine2@23.6.0", "jest-leak-detector@23.6.0",
+        "jest-message-util@23.4.0", "jest-runtime@23.6.0",
+        "jest-util@23.4.0", "jest-worker@23.2.0", "source-map-support@0.5.9",
+        "throat@4.1.0"
+      ]
+    },
+    "jest-resolve-dependencies@23.6.0": {
+      "record": {
+        "name": "jest-resolve-dependencies",
+        "version": "23.6.0",
+        "source":
+          "archive:https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-23.6.0.tgz#sha1:b4526af24c8540d9a3fab102c15081cf509b723d",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [ "jest-regex-util@23.3.0", "jest-snapshot@23.6.0" ]
+    },
+    "jest-resolve@23.6.0": {
+      "record": {
+        "name": "jest-resolve",
+        "version": "23.6.0",
+        "source":
+          "archive:https://registry.npmjs.org/jest-resolve/-/jest-resolve-23.6.0.tgz#sha1:cf1d1a24ce7ee7b23d661c33ba2150f3aebfa0ae",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [
+        "browser-resolve@1.11.3", "chalk@2.4.1", "realpath-native@1.0.2"
+      ]
+    },
+    "jest-regex-util@23.3.0": {
+      "record": {
+        "name": "jest-regex-util",
+        "version": "23.3.0",
+        "source":
+          "archive:https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-23.3.0.tgz#sha1:5f86729547c2785c4002ceaa8f849fe8ca471bc5",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": []
+    },
+    "jest-mock@23.2.0": {
+      "record": {
+        "name": "jest-mock",
+        "version": "23.2.0",
+        "source":
+          "archive:https://registry.npmjs.org/jest-mock/-/jest-mock-23.2.0.tgz#sha1:ad1c60f29e8719d47c26e1138098b6d18b261134",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": []
+    },
+    "jest-message-util@23.4.0": {
+      "record": {
+        "name": "jest-message-util",
+        "version": "23.4.0",
+        "source":
+          "archive:https://registry.npmjs.org/jest-message-util/-/jest-message-util-23.4.0.tgz#sha1:17610c50942349508d01a3d1e0bda2c079086a9f",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [
+        "@babel/code-frame@7.0.0", "chalk@2.4.1", "micromatch@2.3.11",
+        "slash@1.0.0", "stack-utils@1.0.1"
+      ]
+    },
+    "jest-matcher-utils@23.6.0": {
+      "record": {
+        "name": "jest-matcher-utils",
+        "version": "23.6.0",
+        "source":
+          "archive:https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-23.6.0.tgz#sha1:726bcea0c5294261a7417afb6da3186b4b8cac80",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [
+        "chalk@2.4.1", "jest-get-type@22.4.3", "pretty-format@23.6.0"
+      ]
+    },
+    "jest-leak-detector@23.6.0": {
+      "record": {
+        "name": "jest-leak-detector",
+        "version": "23.6.0",
+        "source":
+          "archive:https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-23.6.0.tgz#sha1:e4230fd42cf381a1a1971237ad56897de7e171de",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [ "pretty-format@23.6.0" ]
+    },
+    "jest-jasmine2@23.6.0": {
+      "record": {
+        "name": "jest-jasmine2",
+        "version": "23.6.0",
+        "source":
+          "archive:https://registry.npmjs.org/jest-jasmine2/-/jest-jasmine2-23.6.0.tgz#sha1:840e937f848a6c8638df24360ab869cc718592e0",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [
+        "babel-traverse@6.26.0", "chalk@2.4.1", "co@4.6.0", "expect@23.6.0",
+        "is-generator-fn@1.0.0", "jest-diff@23.6.0", "jest-each@23.6.0",
+        "jest-matcher-utils@23.6.0", "jest-message-util@23.4.0",
+        "jest-snapshot@23.6.0", "jest-util@23.4.0", "pretty-format@23.6.0"
+      ]
+    },
+    "jest-haste-map@23.6.0": {
+      "record": {
+        "name": "jest-haste-map",
+        "version": "23.6.0",
+        "source":
+          "archive:https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-23.6.0.tgz#sha1:2e3eb997814ca696d62afdb3f2529f5bbc935e16",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [
+        "fb-watchman@2.0.0", "graceful-fs@4.1.11", "invariant@2.2.4",
+        "jest-docblock@23.2.0", "jest-serializer@23.0.1",
+        "jest-worker@23.2.0", "micromatch@2.3.11", "sane@2.5.2"
+      ]
+    },
+    "jest-get-type@22.4.3": {
+      "record": {
+        "name": "jest-get-type",
+        "version": "22.4.3",
+        "source":
+          "archive:http://registry.npmjs.org/jest-get-type/-/jest-get-type-22.4.3.tgz#sha1:e3a8504d8479342dd4420236b322869f18900ce4",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": []
+    },
+    "jest-environment-node@23.4.0": {
+      "record": {
+        "name": "jest-environment-node",
+        "version": "23.4.0",
+        "source":
+          "archive:https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-23.4.0.tgz#sha1:57e80ed0841dea303167cce8cd79521debafde10",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [ "jest-mock@23.2.0", "jest-util@23.4.0" ]
+    },
+    "jest-environment-jsdom@23.4.0": {
+      "record": {
+        "name": "jest-environment-jsdom",
+        "version": "23.4.0",
+        "source":
+          "archive:https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-23.4.0.tgz#sha1:056a7952b3fea513ac62a140a2c368c79d9e6023",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [
+        "jest-mock@23.2.0", "jest-util@23.4.0", "jsdom@11.12.0"
+      ]
+    },
+    "jest-each@23.6.0": {
+      "record": {
+        "name": "jest-each",
+        "version": "23.6.0",
+        "source":
+          "archive:https://registry.npmjs.org/jest-each/-/jest-each-23.6.0.tgz#sha1:ba0c3a82a8054387016139c733a05242d3d71575",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [ "chalk@2.4.1", "pretty-format@23.6.0" ]
+    },
+    "jest-docblock@23.2.0": {
+      "record": {
+        "name": "jest-docblock",
+        "version": "23.2.0",
+        "source":
+          "archive:https://registry.npmjs.org/jest-docblock/-/jest-docblock-23.2.0.tgz#sha1:f085e1f18548d99fdd69b20207e6fd55d91383a7",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [ "detect-newline@2.1.0" ]
+    },
+    "jest-diff@23.6.0": {
+      "record": {
+        "name": "jest-diff",
+        "version": "23.6.0",
+        "source":
+          "archive:https://registry.npmjs.org/jest-diff/-/jest-diff-23.6.0.tgz#sha1:1500f3f16e850bb3d71233408089be099f610c7d",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [
+        "chalk@2.4.1", "diff@3.5.0", "jest-get-type@22.4.3",
+        "pretty-format@23.6.0"
+      ]
+    },
+    "jest-config@23.6.0": {
+      "record": {
+        "name": "jest-config",
+        "version": "23.6.0",
+        "source":
+          "archive:https://registry.npmjs.org/jest-config/-/jest-config-23.6.0.tgz#sha1:f82546a90ade2d8c7026fbf6ac5207fc22f8eb1d",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [
+        "babel-core@6.26.3", "babel-jest@23.6.0", "chalk@2.4.1",
+        "glob@7.1.3", "jest-environment-jsdom@23.4.0",
+        "jest-environment-node@23.4.0", "jest-get-type@22.4.3",
+        "jest-jasmine2@23.6.0", "jest-regex-util@23.3.0",
+        "jest-resolve@23.6.0", "jest-util@23.4.0", "jest-validate@23.6.0",
+        "micromatch@2.3.11", "pretty-format@23.6.0"
+      ]
+    },
+    "jest-cli@23.6.0": {
+      "record": {
+        "name": "jest-cli",
+        "version": "23.6.0",
+        "source":
+          "archive:https://registry.npmjs.org/jest-cli/-/jest-cli-23.6.0.tgz#sha1:61ab917744338f443ef2baa282ddffdd658a5da4",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [
+        "ansi-escapes@3.1.0", "chalk@2.4.1", "exit@0.1.2", "glob@7.1.3",
+        "graceful-fs@4.1.11", "import-local@1.0.0", "is-ci@1.2.1",
+        "istanbul-api@1.3.7", "istanbul-lib-coverage@1.2.1",
+        "istanbul-lib-instrument@1.10.2", "istanbul-lib-source-maps@1.2.6",
+        "jest-changed-files@23.4.2", "jest-config@23.6.0",
+        "jest-environment-jsdom@23.4.0", "jest-get-type@22.4.3",
+        "jest-haste-map@23.6.0", "jest-message-util@23.4.0",
+        "jest-regex-util@23.3.0", "jest-resolve-dependencies@23.6.0",
+        "jest-runner@23.6.0", "jest-runtime@23.6.0", "jest-snapshot@23.6.0",
+        "jest-util@23.4.0", "jest-validate@23.6.0", "jest-watcher@23.4.0",
+        "jest-worker@23.2.0", "micromatch@2.3.11", "node-notifier@5.3.0",
+        "prompts@0.1.14", "realpath-native@1.0.2", "rimraf@2.6.2",
+        "slash@1.0.0", "string-length@2.0.0", "strip-ansi@4.0.0",
+        "which@1.3.1", "yargs@11.1.0"
+      ]
+    },
+    "jest-changed-files@23.4.2": {
+      "record": {
+        "name": "jest-changed-files",
+        "version": "23.4.2",
+        "source":
+          "archive:https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-23.4.2.tgz#sha1:1eed688370cd5eebafe4ae93d34bb3b64968fe83",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [ "throat@4.1.0" ]
+    },
+    "jest@23.6.0": {
+      "record": {
+        "name": "jest",
+        "version": "23.6.0",
+        "source":
+          "archive:https://registry.npmjs.org/jest/-/jest-23.6.0.tgz#sha1:ad5835e923ebf6e19e7a1d7529a432edfee7813d",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [ "import-local@1.0.0", "jest-cli@23.6.0" ]
+    },
+    "isurl@1.0.0": {
+      "record": {
+        "name": "isurl",
+        "version": "1.0.0",
+        "source":
+          "archive:https://registry.npmjs.org/isurl/-/isurl-1.0.0.tgz#sha1:b27f4f49f3cdaa3ea44a0a5b7f3462e6edc39d67",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [ "has-to-string-tag-x@1.4.1", "is-object@1.0.1" ]
+    },
+    "istanbul-reports@1.5.1": {
+      "record": {
+        "name": "istanbul-reports",
+        "version": "1.5.1",
+        "source":
+          "archive:https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-1.5.1.tgz#sha1:97e4dbf3b515e8c484caea15d6524eebd3ff4e1a",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [ "handlebars@4.0.12" ]
+    },
+    "istanbul-lib-source-maps@1.2.6": {
+      "record": {
+        "name": "istanbul-lib-source-maps",
+        "version": "1.2.6",
+        "source":
+          "archive:https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-1.2.6.tgz#sha1:37b9ff661580f8fca11232752ee42e08c6675d8f",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [
+        "debug@3.2.6", "istanbul-lib-coverage@1.2.1", "mkdirp@0.5.1",
+        "rimraf@2.6.2", "source-map@0.5.7"
+      ]
+    },
+    "istanbul-lib-report@1.1.5": {
+      "record": {
+        "name": "istanbul-lib-report",
+        "version": "1.1.5",
+        "source":
+          "archive:https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-1.1.5.tgz#sha1:f2a657fc6282f96170aaf281eb30a458f7f4170c",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [
+        "istanbul-lib-coverage@1.2.1", "mkdirp@0.5.1", "path-parse@1.0.6",
+        "supports-color@3.2.3"
+      ]
+    },
+    "istanbul-lib-instrument@1.10.2": {
+      "record": {
+        "name": "istanbul-lib-instrument",
+        "version": "1.10.2",
+        "source":
+          "archive:https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-1.10.2.tgz#sha1:1f55ed10ac3c47f2bdddd5307935126754d0a9ca",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [
+        "babel-generator@6.26.1", "babel-template@6.26.0",
+        "babel-traverse@6.26.0", "babel-types@6.26.0", "babylon@6.18.0",
+        "istanbul-lib-coverage@1.2.1", "semver@5.6.0"
+      ]
+    },
+    "istanbul-lib-hook@1.2.2": {
+      "record": {
+        "name": "istanbul-lib-hook",
+        "version": "1.2.2",
+        "source":
+          "archive:https://registry.npmjs.org/istanbul-lib-hook/-/istanbul-lib-hook-1.2.2.tgz#sha1:bc6bf07f12a641fbf1c85391d0daa8f0aea6bf86",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [ "append-transform@0.4.0" ]
+    },
+    "istanbul-lib-coverage@1.2.1": {
+      "record": {
+        "name": "istanbul-lib-coverage",
+        "version": "1.2.1",
+        "source":
+          "archive:https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-1.2.1.tgz#sha1:ccf7edcd0a0bb9b8f729feeb0930470f9af664f0",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": []
+    },
+    "istanbul-api@1.3.7": {
+      "record": {
+        "name": "istanbul-api",
+        "version": "1.3.7",
+        "source":
+          "archive:https://registry.npmjs.org/istanbul-api/-/istanbul-api-1.3.7.tgz#sha1:a86c770d2b03e11e3f778cd7aedd82d2722092aa",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [
+        "async@2.6.1", "fileset@2.0.3", "istanbul-lib-coverage@1.2.1",
+        "istanbul-lib-hook@1.2.2", "istanbul-lib-instrument@1.10.2",
+        "istanbul-lib-report@1.1.5", "istanbul-lib-source-maps@1.2.6",
+        "istanbul-reports@1.5.1", "js-yaml@3.12.0", "mkdirp@0.5.1",
+        "once@1.4.0"
+      ]
+    },
+    "isstream@0.1.2": {
+      "record": {
+        "name": "isstream",
+        "version": "0.1.2",
+        "source":
+          "archive:https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz#sha1:47e63f7af55afa6f92e1500e690eb8b8529c099a",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": []
+    },
+    "isobject@3.0.1": {
+      "record": {
+        "name": "isobject",
+        "version": "3.0.1",
+        "source":
+          "archive:https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz#sha1:4e431e92b11a9731636aa1f9c8d1ccbcfdab78df",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": []
+    },
+    "isobject@2.1.0": {
+      "record": {
+        "name": "isobject",
+        "version": "2.1.0",
+        "source":
+          "archive:https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz#sha1:f065561096a3f1da2ef46272f815c840d87e0c89",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [ "isarray@1.0.0" ]
+    },
+    "isexe@2.0.0": {
+      "record": {
+        "name": "isexe",
+        "version": "2.0.0",
+        "source":
+          "archive:https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz#sha1:e8fbf374dc556ff8947a10dcb0572d633f2cfa10",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": []
+    },
+    "isarray@1.0.0": {
+      "record": {
+        "name": "isarray",
+        "version": "1.0.0",
+        "source":
+          "archive:https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz#sha1:bb935d48582cba168c06834957a54a3e07124f11",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": []
+    },
+    "is-windows@1.0.2": {
+      "record": {
+        "name": "is-windows",
+        "version": "1.0.2",
+        "source":
+          "archive:https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz#sha1:d1850eb9791ecd18e6182ce12a30f396634bb19d",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": []
+    },
+    "is-utf8@0.2.1": {
+      "record": {
+        "name": "is-utf8",
+        "version": "0.2.1",
+        "source":
+          "archive:https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz#sha1:4b0da1442104d1b336340e80797e865cf39f7d72",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": []
+    },
+    "is-typedarray@1.0.0": {
+      "record": {
+        "name": "is-typedarray",
+        "version": "1.0.0",
+        "source":
+          "archive:https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz#sha1:e479c80858df0c1b11ddda6940f96011fcda4a9a",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": []
+    },
+    "is-symbol@1.0.2": {
+      "record": {
+        "name": "is-symbol",
+        "version": "1.0.2",
+        "source":
+          "archive:https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.2.tgz#sha1:a055f6ae57192caee329e7a860118b497a950f38",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [ "has-symbols@1.0.0" ]
+    },
+    "is-stream@1.1.0": {
+      "record": {
+        "name": "is-stream",
+        "version": "1.1.0",
+        "source":
+          "archive:https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz#sha1:12d4a3dd4e68e0b79ceb8dbc84173ae80d91ca44",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": []
+    },
+    "is-retry-allowed@1.1.0": {
+      "record": {
+        "name": "is-retry-allowed",
+        "version": "1.1.0",
+        "source":
+          "archive:https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-1.1.0.tgz#sha1:11a060568b67339444033d0125a61a20d564fb34",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": []
+    },
+    "is-regex@1.0.4": {
+      "record": {
+        "name": "is-regex",
+        "version": "1.0.4",
+        "source":
+          "archive:https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz#sha1:5517489b547091b0930e095654ced25ee97e9491",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [ "has@1.0.3" ]
+    },
+    "is-primitive@2.0.0": {
+      "record": {
+        "name": "is-primitive",
+        "version": "2.0.0",
+        "source":
+          "archive:https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz#sha1:207bab91638499c07b2adf240a41a87210034575",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": []
+    },
+    "is-posix-bracket@0.1.1": {
+      "record": {
+        "name": "is-posix-bracket",
+        "version": "0.1.1",
+        "source":
+          "archive:https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz#sha1:3334dc79774368e92f016e6fbc0a88f5cd6e6bc4",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": []
+    },
+    "is-plain-object@2.0.4": {
+      "record": {
+        "name": "is-plain-object",
+        "version": "2.0.4",
+        "source":
+          "archive:https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz#sha1:2c163b3fafb1b606d9d17928f05c2a1c38e07677",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [ "isobject@3.0.1" ]
+    },
+    "is-plain-obj@1.1.0": {
+      "record": {
+        "name": "is-plain-obj",
+        "version": "1.1.0",
+        "source":
+          "archive:https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz#sha1:71a50c8429dfca773c92a390a4a03b39fcd51d3e",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": []
+    },
+    "is-object@1.0.1": {
+      "record": {
+        "name": "is-object",
+        "version": "1.0.1",
+        "source":
+          "archive:https://registry.npmjs.org/is-object/-/is-object-1.0.1.tgz#sha1:8952688c5ec2ffd6b03ecc85e769e02903083470",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": []
+    },
+    "is-number@4.0.0": {
+      "record": {
+        "name": "is-number",
+        "version": "4.0.0",
+        "source":
+          "archive:https://registry.npmjs.org/is-number/-/is-number-4.0.0.tgz#sha1:0026e37f5454d73e356dfe6564699867c6a7f0ff",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": []
+    },
+    "is-number@3.0.0": {
+      "record": {
+        "name": "is-number",
+        "version": "3.0.0",
+        "source":
+          "archive:https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz#sha1:24fd6201a4782cf50561c810276afc7d12d71195",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [ "kind-of@3.2.2" ]
+    },
+    "is-number@2.1.0": {
+      "record": {
+        "name": "is-number",
+        "version": "2.1.0",
+        "source":
+          "archive:https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz#sha1:01fcbbb393463a548f2f466cce16dece49db908f",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [ "kind-of@3.2.2" ]
+    },
+    "is-natural-number@4.0.1": {
+      "record": {
+        "name": "is-natural-number",
+        "version": "4.0.1",
+        "source":
+          "archive:https://registry.npmjs.org/is-natural-number/-/is-natural-number-4.0.1.tgz#sha1:ab9d76e1db4ced51e35de0c72ebecf09f734cde8",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": []
+    },
+    "is-glob@2.0.1": {
+      "record": {
+        "name": "is-glob",
+        "version": "2.0.1",
+        "source":
+          "archive:https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz#sha1:d096f926a3ded5600f3fdfd91198cb0888c2d863",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [ "is-extglob@1.0.0" ]
+    },
+    "is-generator-fn@1.0.0": {
+      "record": {
+        "name": "is-generator-fn",
+        "version": "1.0.0",
+        "source":
+          "archive:https://registry.npmjs.org/is-generator-fn/-/is-generator-fn-1.0.0.tgz#sha1:969d49e1bb3329f6bb7f09089be26578b2ddd46a",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": []
+    },
+    "is-fullwidth-code-point@2.0.0": {
+      "record": {
+        "name": "is-fullwidth-code-point",
+        "version": "2.0.0",
+        "source":
+          "archive:https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz#sha1:a3b30a5c4f199183167aaab93beefae3ddfb654f",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": []
+    },
+    "is-fullwidth-code-point@1.0.0": {
+      "record": {
+        "name": "is-fullwidth-code-point",
+        "version": "1.0.0",
+        "source":
+          "archive:https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz#sha1:ef9e31386f031a7f0d643af82fde50c457ef00cb",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [ "number-is-nan@1.0.1" ]
+    },
+    "is-finite@1.0.2": {
+      "record": {
+        "name": "is-finite",
+        "version": "1.0.2",
+        "source":
+          "archive:https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz#sha1:cc6677695602be550ef11e8b4aa6305342b6d0aa",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [ "number-is-nan@1.0.1" ]
+    },
+    "is-extglob@1.0.0": {
+      "record": {
+        "name": "is-extglob",
+        "version": "1.0.0",
+        "source":
+          "archive:https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz#sha1:ac468177c4943405a092fc8f29760c6ffc6206c0",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": []
+    },
+    "is-extendable@1.0.1": {
+      "record": {
+        "name": "is-extendable",
+        "version": "1.0.1",
+        "source":
+          "archive:https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz#sha1:a7470f9e426733d81bd81e1155264e3a3507cab4",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [ "is-plain-object@2.0.4" ]
+    },
+    "is-extendable@0.1.1": {
+      "record": {
+        "name": "is-extendable",
+        "version": "0.1.1",
+        "source":
+          "archive:https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz#sha1:62b110e289a471418e3ec36a617d472e301dfc89",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": []
+    },
+    "is-equal-shallow@0.1.3": {
+      "record": {
+        "name": "is-equal-shallow",
+        "version": "0.1.3",
+        "source":
+          "archive:https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz#sha1:2238098fc221de0bcfa5d9eac4c45d638aa1c534",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [ "is-primitive@2.0.0" ]
+    },
+    "is-dotfile@1.0.3": {
+      "record": {
+        "name": "is-dotfile",
+        "version": "1.0.3",
+        "source":
+          "archive:https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.3.tgz#sha1:a6a2f32ffd2dfb04f5ca25ecd0f6b83cf798a1e1",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": []
+    },
+    "is-descriptor@1.0.2": {
+      "record": {
+        "name": "is-descriptor",
+        "version": "1.0.2",
+        "source":
+          "archive:https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz#sha1:3b159746a66604b04f8c81524ba365c5f14d86ec",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [
+        "is-accessor-descriptor@1.0.0", "is-data-descriptor@1.0.0",
+        "kind-of@6.0.2"
+      ]
+    },
+    "is-descriptor@0.1.6": {
+      "record": {
+        "name": "is-descriptor",
+        "version": "0.1.6",
+        "source":
+          "archive:https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz#sha1:366d8240dde487ca51823b1ab9f07a10a78251ca",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [
+        "is-accessor-descriptor@0.1.6", "is-data-descriptor@0.1.4",
+        "kind-of@5.1.0"
+      ]
+    },
+    "is-date-object@1.0.1": {
+      "record": {
+        "name": "is-date-object",
+        "version": "1.0.1",
+        "source":
+          "archive:https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz#sha1:9aa20eb6aeebbff77fbd33e74ca01b33581d3a16",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": []
+    },
+    "is-data-descriptor@1.0.0": {
+      "record": {
+        "name": "is-data-descriptor",
+        "version": "1.0.0",
+        "source":
+          "archive:https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz#sha1:d84876321d0e7add03990406abbbbd36ba9268c7",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [ "kind-of@6.0.2" ]
+    },
+    "is-data-descriptor@0.1.4": {
+      "record": {
+        "name": "is-data-descriptor",
+        "version": "0.1.4",
+        "source":
+          "archive:https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz#sha1:0b5ee648388e2c860282e793f1856fec3f301b56",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [ "kind-of@3.2.2" ]
+    },
+    "is-ci@1.2.1": {
+      "record": {
+        "name": "is-ci",
+        "version": "1.2.1",
+        "source":
+          "archive:https://registry.npmjs.org/is-ci/-/is-ci-1.2.1.tgz#sha1:e3779c8ee17fccf428488f6e281187f2e632841c",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [ "ci-info@1.6.0" ]
+    },
+    "is-callable@1.1.4": {
+      "record": {
+        "name": "is-callable",
+        "version": "1.1.4",
+        "source":
+          "archive:https://registry.npmjs.org/is-callable/-/is-callable-1.1.4.tgz#sha1:1e1adf219e1eeb684d691f9d6a05ff0d30a24d75",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": []
+    },
+    "is-builtin-module@1.0.0": {
+      "record": {
+        "name": "is-builtin-module",
+        "version": "1.0.0",
+        "source":
+          "archive:http://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz#sha1:540572d34f7ac3119f8f76c30cbc1b1e037affbe",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [ "builtin-modules@1.1.1" ]
+    },
+    "is-buffer@1.1.6": {
+      "record": {
+        "name": "is-buffer",
+        "version": "1.1.6",
+        "source":
+          "archive:https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz#sha1:efaa2ea9daa0d7ab2ea13a97b2b8ad51fefbe8be",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": []
+    },
+    "is-arrayish@0.2.1": {
+      "record": {
+        "name": "is-arrayish",
+        "version": "0.2.1",
+        "source":
+          "archive:https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz#sha1:77c99840527aa8ecb1a8ba697b80645a7a926a9d",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": []
+    },
+    "is-accessor-descriptor@1.0.0": {
+      "record": {
+        "name": "is-accessor-descriptor",
+        "version": "1.0.0",
+        "source":
+          "archive:https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz#sha1:169c2f6d3df1f992618072365c9b0ea1f6878656",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [ "kind-of@6.0.2" ]
+    },
+    "is-accessor-descriptor@0.1.6": {
+      "record": {
+        "name": "is-accessor-descriptor",
+        "version": "0.1.6",
+        "source":
+          "archive:https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz#sha1:a9e12cb3ae8d876727eeef3843f8a0897b5c98d6",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [ "kind-of@3.2.2" ]
+    },
+    "invert-kv@1.0.0": {
+      "record": {
+        "name": "invert-kv",
+        "version": "1.0.0",
+        "source":
+          "archive:https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz#sha1:104a8e4aaca6d3d8cd157a8ef8bfab2d7a3ffdb6",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": []
+    },
+    "invariant@2.2.4": {
+      "record": {
+        "name": "invariant",
+        "version": "2.2.4",
+        "source":
+          "archive:https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz#sha1:610f3c92c9359ce1db616e538008d23ff35158e6",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [ "loose-envify@1.4.0" ]
+    },
+    "into-stream@3.1.0": {
+      "record": {
+        "name": "into-stream",
+        "version": "3.1.0",
+        "source":
+          "archive:http://registry.npmjs.org/into-stream/-/into-stream-3.1.0.tgz#sha1:96fb0a936c12babd6ff1752a17d05616abd094c6",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [ "from2@2.3.0", "p-is-promise@1.1.0" ]
+    },
+    "ini@1.3.5": {
+      "record": {
+        "name": "ini",
+        "version": "1.3.5",
+        "source":
+          "archive:https://registry.npmjs.org/ini/-/ini-1.3.5.tgz#sha1:eee25f56db1c9ec6085e0c22778083f596abf927",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": []
+    },
+    "inherits@2.0.3": {
+      "record": {
+        "name": "inherits",
+        "version": "2.0.3",
+        "source":
+          "archive:https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz#sha1:633c2c83e3da42a502f52466022480f4208261de",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": []
+    },
+    "inflight@1.0.6": {
+      "record": {
+        "name": "inflight",
+        "version": "1.0.6",
+        "source":
+          "archive:https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz#sha1:49bd6331d7d02d0c09bc910a1075ba8165b56df9",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [ "once@1.4.0", "wrappy@1.0.2" ]
+    },
+    "imurmurhash@0.1.4": {
+      "record": {
+        "name": "imurmurhash",
+        "version": "0.1.4",
+        "source":
+          "archive:https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz#sha1:9218b9b2b928a238b13dc4fb6b6d576f231453ea",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": []
+    },
+    "import-local@1.0.0": {
+      "record": {
+        "name": "import-local",
+        "version": "1.0.0",
+        "source":
+          "archive:https://registry.npmjs.org/import-local/-/import-local-1.0.0.tgz#sha1:5e4ffdc03f4fe6c009c6729beb29631c2f8227bc",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [ "pkg-dir@2.0.0", "resolve-cwd@2.0.0" ]
+    },
+    "ignore-walk@3.0.1": {
+      "record": {
+        "name": "ignore-walk",
+        "version": "3.0.1",
+        "source":
+          "archive:https://registry.npmjs.org/ignore-walk/-/ignore-walk-3.0.1.tgz#sha1:a83e62e7d272ac0e3b551aaa82831a19b69f82f8",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [ "minimatch@3.0.4" ]
+    },
+    "ieee754@1.1.12": {
+      "record": {
+        "name": "ieee754",
+        "version": "1.1.12",
+        "source":
+          "archive:https://registry.npmjs.org/ieee754/-/ieee754-1.1.12.tgz#sha1:50bf24e5b9c8bb98af4964c941cdb0918da7b60b",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": []
+    },
+    "iconv-lite@0.4.24": {
+      "record": {
+        "name": "iconv-lite",
+        "version": "0.4.24",
+        "source":
+          "archive:https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz#sha1:2022b4b25fbddc21d2f524974a474aafe733908b",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [ "safer-buffer@2.1.2" ]
+    },
+    "http-signature@1.2.0": {
+      "record": {
+        "name": "http-signature",
+        "version": "1.2.0",
+        "source":
+          "archive:https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz#sha1:9aecd925114772f3d95b65a60abb8f7c18fbace1",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [ "assert-plus@1.0.0", "jsprim@1.4.1", "sshpk@1.15.1" ]
+    },
+    "http-cache-semantics@3.8.1": {
+      "record": {
+        "name": "http-cache-semantics",
+        "version": "3.8.1",
+        "source":
+          "archive:https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-3.8.1.tgz#sha1:39b0e16add9b605bf0a9ef3d9daaf4843b4cacd2",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": []
+    },
+    "html-encoding-sniffer@1.0.2": {
+      "record": {
+        "name": "html-encoding-sniffer",
+        "version": "1.0.2",
+        "source":
+          "archive:https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-1.0.2.tgz#sha1:e70d84b94da53aa375e11fe3a351be6642ca46f8",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [ "whatwg-encoding@1.0.5" ]
+    },
+    "hosted-git-info@2.7.1": {
+      "record": {
+        "name": "hosted-git-info",
+        "version": "2.7.1",
+        "source":
+          "archive:https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.7.1.tgz#sha1:97f236977bd6e125408930ff6de3eec6281ec047",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": []
+    },
+    "home-or-tmp@2.0.0": {
+      "record": {
+        "name": "home-or-tmp",
+        "version": "2.0.0",
+        "source":
+          "archive:https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-2.0.0.tgz#sha1:e36c3f2d2cae7d746a857e38d18d5f32a7882db8",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [ "os-homedir@1.0.2", "os-tmpdir@1.0.2" ]
+    },
+    "has-values@1.0.0": {
+      "record": {
+        "name": "has-values",
+        "version": "1.0.0",
+        "source":
+          "archive:https://registry.npmjs.org/has-values/-/has-values-1.0.0.tgz#sha1:95b0b63fec2146619a6fe57fe75628d5a39efe4f",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [ "is-number@3.0.0", "kind-of@4.0.0" ]
+    },
+    "has-values@0.1.4": {
+      "record": {
+        "name": "has-values",
+        "version": "0.1.4",
+        "source":
+          "archive:https://registry.npmjs.org/has-values/-/has-values-0.1.4.tgz#sha1:6d61de95d91dfca9b9a02089ad384bff8f62b771",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": []
+    },
+    "has-value@1.0.0": {
+      "record": {
+        "name": "has-value",
+        "version": "1.0.0",
+        "source":
+          "archive:https://registry.npmjs.org/has-value/-/has-value-1.0.0.tgz#sha1:18b281da585b1c5c51def24c930ed29a0be6b177",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [
+        "get-value@2.0.6", "has-values@1.0.0", "isobject@3.0.1"
+      ]
+    },
+    "has-value@0.3.1": {
+      "record": {
+        "name": "has-value",
+        "version": "0.3.1",
+        "source":
+          "archive:https://registry.npmjs.org/has-value/-/has-value-0.3.1.tgz#sha1:7b1f58bada62ca827ec0a2078025654845995e1f",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [
+        "get-value@2.0.6", "has-values@0.1.4", "isobject@2.1.0"
+      ]
+    },
+    "has-unicode@2.0.1": {
+      "record": {
+        "name": "has-unicode",
+        "version": "2.0.1",
+        "source":
+          "archive:https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz#sha1:e0e6fe6a28cf51138855e086d1691e771de2a8b9",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": []
+    },
+    "has-to-string-tag-x@1.4.1": {
+      "record": {
+        "name": "has-to-string-tag-x",
+        "version": "1.4.1",
+        "source":
+          "archive:https://registry.npmjs.org/has-to-string-tag-x/-/has-to-string-tag-x-1.4.1.tgz#sha1:a045ab383d7b4b2012a00148ab0aa5f290044d4d",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [ "has-symbol-support-x@1.4.2" ]
+    },
+    "has-symbols@1.0.0": {
+      "record": {
+        "name": "has-symbols",
+        "version": "1.0.0",
+        "source":
+          "archive:https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.0.tgz#sha1:ba1a8f1af2a0fc39650f5c850367704122063b44",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": []
+    },
+    "has-symbol-support-x@1.4.2": {
+      "record": {
+        "name": "has-symbol-support-x",
+        "version": "1.4.2",
+        "source":
+          "archive:https://registry.npmjs.org/has-symbol-support-x/-/has-symbol-support-x-1.4.2.tgz#sha1:1409f98bc00247da45da67cee0a36f282ff26455",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": []
+    },
+    "has-flag@3.0.0": {
+      "record": {
+        "name": "has-flag",
+        "version": "3.0.0",
+        "source":
+          "archive:https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz#sha1:b5d454dc2199ae225699f3467e5a07f3b955bafd",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": []
+    },
+    "has-flag@1.0.0": {
+      "record": {
+        "name": "has-flag",
+        "version": "1.0.0",
+        "source":
+          "archive:https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz#sha1:9d9e793165ce017a00f00418c43f942a7b1d11fa",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": []
+    },
+    "has-ansi@2.0.0": {
+      "record": {
+        "name": "has-ansi",
+        "version": "2.0.0",
+        "source":
+          "archive:https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz#sha1:34f5049ce1ecdf2b0649af3ef24e45ed35416d91",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [ "ansi-regex@2.1.1" ]
+    },
+    "has@1.0.3": {
+      "record": {
+        "name": "has",
+        "version": "1.0.3",
+        "source":
+          "archive:https://registry.npmjs.org/has/-/has-1.0.3.tgz#sha1:722d7cbfc1f6aa8241f16dd814e011e1f41e8796",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [ "function-bind@1.1.1" ]
+    },
+    "har-validator@5.1.0": {
+      "record": {
+        "name": "har-validator",
+        "version": "5.1.0",
+        "source":
+          "archive:https://registry.npmjs.org/har-validator/-/har-validator-5.1.0.tgz#sha1:44657f5688a22cfd4b72486e81b3a3fb11742c29",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [ "ajv@5.5.2", "har-schema@2.0.0" ]
+    },
+    "har-schema@2.0.0": {
+      "record": {
+        "name": "har-schema",
+        "version": "2.0.0",
+        "source":
+          "archive:https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz#sha1:a94c2224ebcac04782a0d9035521f24735b7ec92",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": []
+    },
+    "handlebars@4.0.12": {
+      "record": {
+        "name": "handlebars",
+        "version": "4.0.12",
+        "source":
+          "archive:https://registry.npmjs.org/handlebars/-/handlebars-4.0.12.tgz#sha1:2c15c8a96d46da5e266700518ba8cb8d919d5bc5",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [
+        "async@2.6.1", "optimist@0.6.1", "source-map@0.6.1",
+        "uglify-js@3.4.9"
+      ]
+    },
+    "growly@1.3.0": {
+      "record": {
+        "name": "growly",
+        "version": "1.3.0",
+        "source":
+          "archive:https://registry.npmjs.org/growly/-/growly-1.3.0.tgz#sha1:f10748cbe76af964b7c96c93c6bcc28af120c081",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": []
+    },
+    "graceful-readlink@1.0.1": {
+      "record": {
+        "name": "graceful-readlink",
+        "version": "1.0.1",
+        "source":
+          "archive:https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz#sha1:4cafad76bc62f02fa039b2f94e9a3dd3a391a725",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": []
+    },
+    "graceful-fs@4.1.11": {
+      "record": {
+        "name": "graceful-fs",
+        "version": "4.1.11",
+        "source":
+          "archive:https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz#sha1:0e8bdfe4d1ddb8854d64e04ea7c00e2a026e5658",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": []
+    },
+    "got@8.3.2": {
+      "record": {
+        "name": "got",
+        "version": "8.3.2",
+        "source":
+          "archive:https://registry.npmjs.org/got/-/got-8.3.2.tgz#sha1:1d23f64390e97f776cac52e5b936e5f514d2e937",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [
+        "@sindresorhus/is@0.7.0", "cacheable-request@2.1.4",
+        "decompress-response@3.3.0", "duplexer3@0.1.4", "get-stream@3.0.0",
+        "into-stream@3.1.0", "is-retry-allowed@1.1.0", "isurl@1.0.0",
+        "lowercase-keys@1.0.1", "mimic-response@1.0.1", "p-cancelable@0.4.1",
+        "p-timeout@2.0.1", "pify@3.0.0", "safe-buffer@5.1.2",
+        "timed-out@4.0.1", "url-parse-lax@3.0.0", "url-to-options@1.0.1"
+      ]
+    },
+    "globals@9.18.0": {
+      "record": {
+        "name": "globals",
+        "version": "9.18.0",
+        "source":
+          "archive:https://registry.npmjs.org/globals/-/globals-9.18.0.tgz#sha1:aa3896b3e69b487f17e31ed2143d69a8e30c2d8a",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": []
+    },
+    "glob-parent@2.0.0": {
+      "record": {
+        "name": "glob-parent",
+        "version": "2.0.0",
+        "source":
+          "archive:https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz#sha1:81383d72db054fcccf5336daa902f182f6edbb28",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [ "is-glob@2.0.1" ]
+    },
+    "glob-base@0.3.0": {
+      "record": {
+        "name": "glob-base",
+        "version": "0.3.0",
+        "source":
+          "archive:https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz#sha1:dbb164f6221b1c0b1ccf82aea328b497df0ea3c4",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [ "glob-parent@2.0.0", "is-glob@2.0.1" ]
+    },
+    "glob@7.1.3": {
+      "record": {
+        "name": "glob",
+        "version": "7.1.3",
+        "source":
+          "archive:https://registry.npmjs.org/glob/-/glob-7.1.3.tgz#sha1:3960832d3f1574108342dafd3a67b332c0969df1",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [
+        "fs.realpath@1.0.0", "inflight@1.0.6", "inherits@2.0.3",
+        "minimatch@3.0.4", "once@1.4.0", "path-is-absolute@1.0.1"
+      ]
+    },
+    "getpass@0.1.7": {
+      "record": {
+        "name": "getpass",
+        "version": "0.1.7",
+        "source":
+          "archive:https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz#sha1:5eff8e3e684d569ae4cb2b1282604e8ba62149fa",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [ "assert-plus@1.0.0" ]
+    },
+    "get-value@2.0.6": {
+      "record": {
+        "name": "get-value",
+        "version": "2.0.6",
+        "source":
+          "archive:https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz#sha1:dc15ca1c672387ca76bd37ac0a395ba2042a2c28",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": []
+    },
+    "get-stream@3.0.0": {
+      "record": {
+        "name": "get-stream",
+        "version": "3.0.0",
+        "source":
+          "archive:http://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz#sha1:8e943d1358dc37555054ecbe2edb05aa174ede14",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": []
+    },
+    "get-stream@2.3.1": {
+      "record": {
+        "name": "get-stream",
+        "version": "2.3.1",
+        "source":
+          "archive:http://registry.npmjs.org/get-stream/-/get-stream-2.3.1.tgz#sha1:5f38f93f346009666ee0150a054167f91bdd95de",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [ "object-assign@4.1.1", "pinkie-promise@2.0.1" ]
+    },
+    "get-proxy@2.1.0": {
+      "record": {
+        "name": "get-proxy",
+        "version": "2.1.0",
+        "source":
+          "archive:https://registry.npmjs.org/get-proxy/-/get-proxy-2.1.0.tgz#sha1:349f2b4d91d44c4d4d4e9cba2ad90143fac5ef93",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [ "npm-conf@1.1.3" ]
+    },
+    "get-caller-file@1.0.3": {
+      "record": {
+        "name": "get-caller-file",
+        "version": "1.0.3",
+        "source":
+          "archive:https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.3.tgz#sha1:f978fa4c90d1dfe7ff2d6beda2a515e713bdcf4a",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": []
+    },
+    "gauge@2.7.4": {
+      "record": {
+        "name": "gauge",
+        "version": "2.7.4",
+        "source":
+          "archive:https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz#sha1:2c03405c7538c39d7eb37b317022e325fb018bf7",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [
+        "aproba@1.2.0", "console-control-strings@1.1.0", "has-unicode@2.0.1",
+        "object-assign@4.1.1", "signal-exit@3.0.2", "string-width@1.0.2",
+        "strip-ansi@3.0.1", "wide-align@1.1.3"
+      ]
+    },
+    "function-bind@1.1.1": {
+      "record": {
+        "name": "function-bind",
+        "version": "1.1.1",
+        "source":
+          "archive:https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz#sha1:a56899d3ea3c9bab874bb9773b7c5ede92f4895d",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": []
+    },
+    "fsevents@1.2.4": {
+      "record": {
+        "name": "fsevents",
+        "version": "1.2.4",
+        "source":
+          "archive:https://registry.npmjs.org/fsevents/-/fsevents-1.2.4.tgz#sha1:f41dcb1af2582af3692da36fc55cbd8e1041c426",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [ "nan@2.11.1", "node-pre-gyp@0.10.3" ]
+    },
+    "fs.realpath@1.0.0": {
+      "record": {
+        "name": "fs.realpath",
+        "version": "1.0.0",
+        "source":
+          "archive:https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz#sha1:1504ad2523158caa40db4a2787cb01411994ea4f",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": []
+    },
+    "fs-minipass@1.2.5": {
+      "record": {
+        "name": "fs-minipass",
+        "version": "1.2.5",
+        "source":
+          "archive:https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.5.tgz#sha1:06c277218454ec288df77ada54a03b8702aacb9d",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [ "minipass@2.3.4" ]
+    },
+    "fs-constants@1.0.0": {
+      "record": {
+        "name": "fs-constants",
+        "version": "1.0.0",
+        "source":
+          "archive:https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz#sha1:6be0de9be998ce16af8afc24497b9ee9b7ccd9ad",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": []
+    },
+    "from2@2.3.0": {
+      "record": {
+        "name": "from2",
+        "version": "2.3.0",
+        "source":
+          "archive:https://registry.npmjs.org/from2/-/from2-2.3.0.tgz#sha1:8bfb5502bde4a4d36cfdeea007fcca21d7e382af",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [ "inherits@2.0.3", "readable-stream@2.3.6" ]
+    },
+    "fragment-cache@0.2.1": {
+      "record": {
+        "name": "fragment-cache",
+        "version": "0.2.1",
+        "source":
+          "archive:https://registry.npmjs.org/fragment-cache/-/fragment-cache-0.2.1.tgz#sha1:4290fad27f13e89be7f33799c6bc5a0abfff0d19",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [ "map-cache@0.2.2" ]
+    },
+    "form-data@2.3.3": {
+      "record": {
+        "name": "form-data",
+        "version": "2.3.3",
+        "source":
+          "archive:https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz#sha1:dcce52c05f644f298c6a7ab936bd724ceffbf3a6",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [
+        "asynckit@0.4.0", "combined-stream@1.0.7", "mime-types@2.1.21"
+      ]
+    },
+    "forever-agent@0.6.1": {
+      "record": {
+        "name": "forever-agent",
+        "version": "0.6.1",
+        "source":
+          "archive:https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz#sha1:fbc71f0c41adeb37f96c577ad1ed42d8fdacca91",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": []
+    },
+    "for-own@0.1.5": {
+      "record": {
+        "name": "for-own",
+        "version": "0.1.5",
+        "source":
+          "archive:https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz#sha1:5265c681a4f294dabbf17c9509b6763aa84510ce",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [ "for-in@1.0.2" ]
+    },
+    "for-in@1.0.2": {
+      "record": {
+        "name": "for-in",
+        "version": "1.0.2",
+        "source":
+          "archive:https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz#sha1:81068d295a8142ec0ac726c6e2200c30fb6d5e80",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": []
+    },
+    "find-up@2.1.0": {
+      "record": {
+        "name": "find-up",
+        "version": "2.1.0",
+        "source":
+          "archive:https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz#sha1:45d1b7e506c717ddd482775a2b77920a3c0c57a7",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [ "locate-path@2.0.0" ]
+    },
+    "find-up@1.1.2": {
+      "record": {
+        "name": "find-up",
+        "version": "1.1.2",
+        "source":
+          "archive:https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz#sha1:6b2e9822b1a2ce0a60ab64d610eccad53cb24d0f",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [ "path-exists@2.1.0", "pinkie-promise@2.0.1" ]
+    },
+    "fill-range@4.0.0": {
+      "record": {
+        "name": "fill-range",
+        "version": "4.0.0",
+        "source":
+          "archive:https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz#sha1:d544811d428f98eb06a63dc402d2403c328c38f7",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [
+        "extend-shallow@2.0.1", "is-number@3.0.0", "repeat-string@1.6.1",
+        "to-regex-range@2.1.1"
+      ]
+    },
+    "fill-range@2.2.4": {
+      "record": {
+        "name": "fill-range",
+        "version": "2.2.4",
+        "source":
+          "archive:https://registry.npmjs.org/fill-range/-/fill-range-2.2.4.tgz#sha1:eb1e773abb056dcd8df2bfdf6af59b8b3a936565",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [
+        "is-number@2.1.0", "isobject@2.1.0", "randomatic@3.1.0",
+        "repeat-element@1.1.3", "repeat-string@1.6.1"
+      ]
+    },
+    "fileset@2.0.3": {
+      "record": {
+        "name": "fileset",
+        "version": "2.0.3",
+        "source":
+          "archive:https://registry.npmjs.org/fileset/-/fileset-2.0.3.tgz#sha1:8e7548a96d3cc2327ee5e674168723a333bba2a0",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [ "glob@7.1.3", "minimatch@3.0.4" ]
+    },
+    "filenamify@2.1.0": {
+      "record": {
+        "name": "filenamify",
+        "version": "2.1.0",
+        "source":
+          "archive:https://registry.npmjs.org/filenamify/-/filenamify-2.1.0.tgz#sha1:88faf495fb1b47abfd612300002a16228c677ee9",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [
+        "filename-reserved-regex@2.0.0", "strip-outer@1.0.1",
+        "trim-repeated@1.0.0"
+      ]
+    },
+    "filename-reserved-regex@2.0.0": {
+      "record": {
+        "name": "filename-reserved-regex",
+        "version": "2.0.0",
+        "source":
+          "archive:https://registry.npmjs.org/filename-reserved-regex/-/filename-reserved-regex-2.0.0.tgz#sha1:abf73dfab735d045440abfea2d91f389ebbfa229",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": []
+    },
+    "filename-regex@2.0.1": {
+      "record": {
+        "name": "filename-regex",
+        "version": "2.0.1",
+        "source":
+          "archive:https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.1.tgz#sha1:c1c4b9bee3e09725ddb106b75c1e301fe2f18b26",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": []
+    },
+    "file-type@8.1.0": {
+      "record": {
+        "name": "file-type",
+        "version": "8.1.0",
+        "source":
+          "archive:https://registry.npmjs.org/file-type/-/file-type-8.1.0.tgz#sha1:244f3b7ef641bbe0cca196c7276e4b332399f68c",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": []
+    },
+    "file-type@6.2.0": {
+      "record": {
+        "name": "file-type",
+        "version": "6.2.0",
+        "source":
+          "archive:https://registry.npmjs.org/file-type/-/file-type-6.2.0.tgz#sha1:e50cd75d356ffed4e306dc4f5bcf52a79903a919",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": []
+    },
+    "file-type@5.2.0": {
+      "record": {
+        "name": "file-type",
+        "version": "5.2.0",
+        "source":
+          "archive:https://registry.npmjs.org/file-type/-/file-type-5.2.0.tgz#sha1:2ddbea7c73ffe36368dfae49dc338c058c2b8ad6",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": []
+    },
+    "file-type@4.4.0": {
+      "record": {
+        "name": "file-type",
+        "version": "4.4.0",
+        "source":
+          "archive:https://registry.npmjs.org/file-type/-/file-type-4.4.0.tgz#sha1:1b600e5fca1fbdc6e80c0a70c71c8dba5f7906c5",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": []
+    },
+    "file-type@3.9.0": {
+      "record": {
+        "name": "file-type",
+        "version": "3.9.0",
+        "source":
+          "archive:http://registry.npmjs.org/file-type/-/file-type-3.9.0.tgz#sha1:257a078384d1db8087bc449d107d52a52672b9e9",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": []
+    },
+    "fd-slicer@1.1.0": {
+      "record": {
+        "name": "fd-slicer",
+        "version": "1.1.0",
+        "source":
+          "archive:https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz#sha1:25c7c89cb1f9077f8891bbe61d8f390eae256f1e",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [ "pend@1.2.0" ]
+    },
+    "fb-watchman@2.0.0": {
+      "record": {
+        "name": "fb-watchman",
+        "version": "2.0.0",
+        "source":
+          "archive:https://registry.npmjs.org/fb-watchman/-/fb-watchman-2.0.0.tgz#sha1:54e9abf7dfa2f26cd9b1636c588c1afc05de5d58",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [ "bser@2.0.0" ]
+    },
+    "fast-levenshtein@2.0.6": {
+      "record": {
+        "name": "fast-levenshtein",
+        "version": "2.0.6",
+        "source":
+          "archive:https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#sha1:3d8a5c66883a16a30ca8643e851f19baa7797917",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": []
+    },
+    "fast-json-stable-stringify@2.0.0": {
+      "record": {
+        "name": "fast-json-stable-stringify",
+        "version": "2.0.0",
+        "source":
+          "archive:https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz#sha1:d5142c0caee6b1189f87d3a76111064f86c8bbf2",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": []
+    },
+    "fast-deep-equal@1.1.0": {
+      "record": {
+        "name": "fast-deep-equal",
+        "version": "1.1.0",
+        "source":
+          "archive:https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz#sha1:c053477817c86b51daa853c81e059b733d023614",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": []
+    },
+    "extsprintf@1.3.0": {
+      "record": {
+        "name": "extsprintf",
+        "version": "1.3.0",
+        "source":
+          "archive:https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz#sha1:96918440e3041a7a414f8c52e3c574eb3c3e1e05",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": []
+    },
+    "extglob@2.0.4": {
+      "record": {
+        "name": "extglob",
+        "version": "2.0.4",
+        "source":
+          "archive:https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz#sha1:ad00fe4dc612a9232e8718711dc5cb5ab0285543",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [
+        "array-unique@0.3.2", "define-property@1.0.0",
+        "expand-brackets@2.1.4", "extend-shallow@2.0.1",
+        "fragment-cache@0.2.1", "regex-not@1.0.2", "snapdragon@0.8.2",
+        "to-regex@3.0.2"
+      ]
+    },
+    "extglob@0.3.2": {
+      "record": {
+        "name": "extglob",
+        "version": "0.3.2",
+        "source":
+          "archive:https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz#sha1:2e18ff3d2f49ab2765cec9023f011daa8d8349a1",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [ "is-extglob@1.0.0" ]
+    },
+    "extend-shallow@3.0.2": {
+      "record": {
+        "name": "extend-shallow",
+        "version": "3.0.2",
+        "source":
+          "archive:https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz#sha1:26a71aaf073b39fb2127172746131c2704028db8",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [ "assign-symbols@1.0.0", "is-extendable@1.0.1" ]
+    },
+    "extend-shallow@2.0.1": {
+      "record": {
+        "name": "extend-shallow",
+        "version": "2.0.1",
+        "source":
+          "archive:https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz#sha1:51af7d614ad9a9f610ea1bafbb989d6b1c56890f",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [ "is-extendable@0.1.1" ]
+    },
+    "extend@3.0.2": {
+      "record": {
+        "name": "extend",
+        "version": "3.0.2",
+        "source":
+          "archive:https://registry.npmjs.org/extend/-/extend-3.0.2.tgz#sha1:f8b1136b4071fbd8eb140aff858b1019ec2915fa",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": []
+    },
+    "ext-name@5.0.0": {
+      "record": {
+        "name": "ext-name",
+        "version": "5.0.0",
+        "source":
+          "archive:https://registry.npmjs.org/ext-name/-/ext-name-5.0.0.tgz#sha1:70781981d183ee15d13993c8822045c506c8f0a6",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [ "ext-list@2.2.2", "sort-keys-length@1.0.1" ]
+    },
+    "ext-list@2.2.2": {
+      "record": {
+        "name": "ext-list",
+        "version": "2.2.2",
+        "source":
+          "archive:https://registry.npmjs.org/ext-list/-/ext-list-2.2.2.tgz#sha1:0b98e64ed82f5acf0f2931babf69212ef52ddd37",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [ "mime-db@1.37.0" ]
+    },
+    "expect@23.6.0": {
+      "record": {
+        "name": "expect",
+        "version": "23.6.0",
+        "source":
+          "archive:https://registry.npmjs.org/expect/-/expect-23.6.0.tgz#sha1:1e0c8d3ba9a581c87bd71fb9bc8862d443425f98",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [
+        "ansi-styles@3.2.1", "jest-diff@23.6.0", "jest-get-type@22.4.3",
+        "jest-matcher-utils@23.6.0", "jest-message-util@23.4.0",
+        "jest-regex-util@23.3.0"
+      ]
+    },
+    "expand-range@1.8.2": {
+      "record": {
+        "name": "expand-range",
+        "version": "1.8.2",
+        "source":
+          "archive:https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz#sha1:a299effd335fe2721ebae8e257ec79644fc85337",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [ "fill-range@2.2.4" ]
+    },
+    "expand-brackets@2.1.4": {
+      "record": {
+        "name": "expand-brackets",
+        "version": "2.1.4",
+        "source":
+          "archive:https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz#sha1:b77735e315ce30f6b6eff0f83b04151a22449622",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [
+        "debug@2.6.9", "define-property@0.2.5", "extend-shallow@2.0.1",
+        "posix-character-classes@0.1.1", "regex-not@1.0.2",
+        "snapdragon@0.8.2", "to-regex@3.0.2"
+      ]
+    },
+    "expand-brackets@0.1.5": {
+      "record": {
+        "name": "expand-brackets",
+        "version": "0.1.5",
+        "source":
+          "archive:https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz#sha1:df07284e342a807cd733ac5af72411e581d1177b",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [ "is-posix-bracket@0.1.1" ]
+    },
+    "exit@0.1.2": {
+      "record": {
+        "name": "exit",
+        "version": "0.1.2",
+        "source":
+          "archive:https://registry.npmjs.org/exit/-/exit-0.1.2.tgz#sha1:0632638f8d877cc82107d30a0fff1a17cba1cd0c",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": []
+    },
+    "execa@0.7.0": {
+      "record": {
+        "name": "execa",
+        "version": "0.7.0",
+        "source":
+          "archive:https://registry.npmjs.org/execa/-/execa-0.7.0.tgz#sha1:944becd34cc41ee32a63a9faf27ad5a65fc59777",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [
+        "cross-spawn@5.1.0", "get-stream@3.0.0", "is-stream@1.1.0",
+        "npm-run-path@2.0.2", "p-finally@1.0.0", "signal-exit@3.0.2",
+        "strip-eof@1.0.0"
+      ]
+    },
+    "exec-sh@0.2.2": {
+      "record": {
+        "name": "exec-sh",
+        "version": "0.2.2",
+        "source":
+          "archive:https://registry.npmjs.org/exec-sh/-/exec-sh-0.2.2.tgz#sha1:2a5e7ffcbd7d0ba2755bdecb16e5a427dfbdec36",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [ "merge@1.2.0" ]
+    },
+    "esutils@2.0.2": {
+      "record": {
+        "name": "esutils",
+        "version": "2.0.2",
+        "source":
+          "archive:https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz#sha1:0abf4f1caa5bcb1f7a9d8acc6dea4faaa04bac9b",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": []
+    },
+    "estraverse@4.2.0": {
+      "record": {
+        "name": "estraverse",
+        "version": "4.2.0",
+        "source":
+          "archive:https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz#sha1:0dee3fed31fcd469618ce7342099fc1afa0bdb13",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": []
+    },
+    "esprima@4.0.1": {
+      "record": {
+        "name": "esprima",
+        "version": "4.0.1",
+        "source":
+          "archive:https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz#sha1:13b04cdb3e6c5d19df91ab6987a8695619b0aa71",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": []
+    },
+    "esprima@3.1.3": {
+      "record": {
+        "name": "esprima",
+        "version": "3.1.3",
+        "source":
+          "archive:https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz#sha1:fdca51cee6133895e3c88d535ce49dbff62a4633",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": []
+    },
+    "escodegen@1.11.0": {
+      "record": {
+        "name": "escodegen",
+        "version": "1.11.0",
+        "source":
+          "archive:https://registry.npmjs.org/escodegen/-/escodegen-1.11.0.tgz#sha1:b27a9389481d5bfd5bec76f7bb1eb3f8f4556589",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [
+        "esprima@3.1.3", "estraverse@4.2.0", "esutils@2.0.2",
+        "optionator@0.8.2", "source-map@0.6.1"
+      ]
+    },
+    "escape-string-regexp@1.0.5": {
+      "record": {
+        "name": "escape-string-regexp",
+        "version": "1.0.5",
+        "source":
+          "archive:https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#sha1:1b61c0562190a8dff6ae3bb2cf0200ca130b86d4",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": []
+    },
+    "es-to-primitive@1.2.0": {
+      "record": {
+        "name": "es-to-primitive",
+        "version": "1.2.0",
+        "source":
+          "archive:https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.0.tgz#sha1:edf72478033456e8dda8ef09e00ad9650707f377",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [
+        "is-callable@1.1.4", "is-date-object@1.0.1", "is-symbol@1.0.2"
+      ]
+    },
+    "es-abstract@1.12.0": {
+      "record": {
+        "name": "es-abstract",
+        "version": "1.12.0",
+        "source":
+          "archive:https://registry.npmjs.org/es-abstract/-/es-abstract-1.12.0.tgz#sha1:9dbbdd27c6856f0001421ca18782d786bf8a6165",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [
+        "es-to-primitive@1.2.0", "function-bind@1.1.1", "has@1.0.3",
+        "is-callable@1.1.4", "is-regex@1.0.4"
+      ]
+    },
+    "error-ex@1.3.2": {
+      "record": {
+        "name": "error-ex",
+        "version": "1.3.2",
+        "source":
+          "archive:https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz#sha1:b4ac40648107fdcdcfae242f428bea8a14d4f1bf",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [ "is-arrayish@0.2.1" ]
+    },
+    "end-of-stream@1.4.1": {
+      "record": {
+        "name": "end-of-stream",
+        "version": "1.4.1",
+        "source":
+          "archive:https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz#sha1:ed29634d19baba463b6ce6b80a37213eab71ec43",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [ "once@1.4.0" ]
+    },
+    "ecc-jsbn@0.1.2": {
+      "record": {
+        "name": "ecc-jsbn",
+        "version": "0.1.2",
+        "source":
+          "archive:https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz#sha1:3a83a904e54353287874c564b7549386849a98c9",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [ "jsbn@0.1.1", "safer-buffer@2.1.2" ]
+    },
+    "duplexer3@0.1.4": {
+      "record": {
+        "name": "duplexer3",
+        "version": "0.1.4",
+        "source":
+          "archive:https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.4.tgz#sha1:ee01dd1cac0ed3cbc7fdbea37dc0a8f1ce002ce2",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": []
+    },
+    "download@7.1.0": {
+      "record": {
+        "name": "download",
+        "version": "7.1.0",
+        "source":
+          "archive:https://registry.npmjs.org/download/-/download-7.1.0.tgz#sha1:9059aa9d70b503ee76a132897be6dec8e5587233",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [
+        "archive-type@4.0.0", "caw@2.0.1", "content-disposition@0.5.2",
+        "decompress@4.2.0", "ext-name@5.0.0", "file-type@8.1.0",
+        "filenamify@2.1.0", "get-stream@3.0.0", "got@8.3.2",
+        "make-dir@1.3.0", "p-event@2.1.0", "pify@3.0.0"
+      ]
+    },
+    "domexception@1.0.1": {
+      "record": {
+        "name": "domexception",
+        "version": "1.0.1",
+        "source":
+          "archive:https://registry.npmjs.org/domexception/-/domexception-1.0.1.tgz#sha1:937442644ca6a31261ef36e3ec677fe805582c90",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [ "webidl-conversions@4.0.2" ]
+    },
+    "diff@3.5.0": {
+      "record": {
+        "name": "diff",
+        "version": "3.5.0",
+        "source":
+          "archive:https://registry.npmjs.org/diff/-/diff-3.5.0.tgz#sha1:800c0dd1e0a8bfbc95835c202ad220fe317e5a12",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": []
+    },
+    "detect-newline@2.1.0": {
+      "record": {
+        "name": "detect-newline",
+        "version": "2.1.0",
+        "source":
+          "archive:https://registry.npmjs.org/detect-newline/-/detect-newline-2.1.0.tgz#sha1:f41f1c10be4b00e87b5f13da680759f2c5bfd3e2",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": []
+    },
+    "detect-libc@1.0.3": {
+      "record": {
+        "name": "detect-libc",
+        "version": "1.0.3",
+        "source":
+          "archive:https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz#sha1:fa137c4bd698edf55cd5cd02ac559f91a4c4ba9b",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": []
+    },
+    "detect-indent@4.0.0": {
+      "record": {
+        "name": "detect-indent",
+        "version": "4.0.0",
+        "source":
+          "archive:https://registry.npmjs.org/detect-indent/-/detect-indent-4.0.0.tgz#sha1:f76d064352cdf43a1cb6ce619c4ee3a9475de208",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [ "repeating@2.0.1" ]
+    },
+    "delegates@1.0.0": {
+      "record": {
+        "name": "delegates",
+        "version": "1.0.0",
+        "source":
+          "archive:https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz#sha1:84c6e159b81904fdca59a0ef44cd870d31250f9a",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": []
+    },
+    "delayed-stream@1.0.0": {
+      "record": {
+        "name": "delayed-stream",
+        "version": "1.0.0",
+        "source":
+          "archive:https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz#sha1:df3ae199acadfb7d440aaae0b29e2272b24ec619",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": []
+    },
+    "define-property@2.0.2": {
+      "record": {
+        "name": "define-property",
+        "version": "2.0.2",
+        "source":
+          "archive:https://registry.npmjs.org/define-property/-/define-property-2.0.2.tgz#sha1:d459689e8d654ba77e02a817f8710d702cb16e9d",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [ "is-descriptor@1.0.2", "isobject@3.0.1" ]
+    },
+    "define-property@1.0.0": {
+      "record": {
+        "name": "define-property",
+        "version": "1.0.0",
+        "source":
+          "archive:https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz#sha1:769ebaaf3f4a63aad3af9e8d304c9bbe79bfb0e6",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [ "is-descriptor@1.0.2" ]
+    },
+    "define-property@0.2.5": {
+      "record": {
+        "name": "define-property",
+        "version": "0.2.5",
+        "source":
+          "archive:https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz#sha1:c35b1ef918ec3c990f9a5bc57be04aacec5c8116",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [ "is-descriptor@0.1.6" ]
+    },
+    "define-properties@1.1.3": {
+      "record": {
+        "name": "define-properties",
+        "version": "1.1.3",
+        "source":
+          "archive:https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz#sha1:cf88da6cbee26fe6db7094f61d870cbd84cee9f1",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [ "object-keys@1.0.12" ]
+    },
+    "default-require-extensions@1.0.0": {
+      "record": {
+        "name": "default-require-extensions",
+        "version": "1.0.0",
+        "source":
+          "archive:https://registry.npmjs.org/default-require-extensions/-/default-require-extensions-1.0.0.tgz#sha1:f37ea15d3e13ffd9b437d33e1a75b5fb97874cb8",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [ "strip-bom@2.0.0" ]
+    },
+    "deep-is@0.1.3": {
+      "record": {
+        "name": "deep-is",
+        "version": "0.1.3",
+        "source":
+          "archive:https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz#sha1:b369d6fb5dbc13eecf524f91b070feedc357cf34",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": []
+    },
+    "deep-extend@0.6.0": {
+      "record": {
+        "name": "deep-extend",
+        "version": "0.6.0",
+        "source":
+          "archive:https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz#sha1:c4fa7c95404a17a9c3e8ca7e1537312b736330ac",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": []
+    },
+    "decompress-unzip@4.0.1": {
+      "record": {
+        "name": "decompress-unzip",
+        "version": "4.0.1",
+        "source":
+          "archive:https://registry.npmjs.org/decompress-unzip/-/decompress-unzip-4.0.1.tgz#sha1:deaaccdfd14aeaf85578f733ae8210f9b4848f69",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [
+        "file-type@3.9.0", "get-stream@2.3.1", "pify@2.3.0", "yauzl@2.10.0"
+      ]
+    },
+    "decompress-targz@4.1.1": {
+      "record": {
+        "name": "decompress-targz",
+        "version": "4.1.1",
+        "source":
+          "archive:https://registry.npmjs.org/decompress-targz/-/decompress-targz-4.1.1.tgz#sha1:c09bc35c4d11f3de09f2d2da53e9de23e7ce1eee",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [
+        "decompress-tar@4.1.1", "file-type@5.2.0", "is-stream@1.1.0"
+      ]
+    },
+    "decompress-tarbz2@4.1.1": {
+      "record": {
+        "name": "decompress-tarbz2",
+        "version": "4.1.1",
+        "source":
+          "archive:https://registry.npmjs.org/decompress-tarbz2/-/decompress-tarbz2-4.1.1.tgz#sha1:3082a5b880ea4043816349f378b56c516be1a39b",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [
+        "decompress-tar@4.1.1", "file-type@6.2.0", "is-stream@1.1.0",
+        "seek-bzip@1.0.5", "unbzip2-stream@1.3.1"
+      ]
+    },
+    "decompress-tar@4.1.1": {
+      "record": {
+        "name": "decompress-tar",
+        "version": "4.1.1",
+        "source":
+          "archive:https://registry.npmjs.org/decompress-tar/-/decompress-tar-4.1.1.tgz#sha1:718cbd3fcb16209716e70a26b84e7ba4592e5af1",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [
+        "file-type@5.2.0", "is-stream@1.1.0", "tar-stream@1.6.2"
+      ]
+    },
+    "decompress-response@3.3.0": {
+      "record": {
+        "name": "decompress-response",
+        "version": "3.3.0",
+        "source":
+          "archive:https://registry.npmjs.org/decompress-response/-/decompress-response-3.3.0.tgz#sha1:80a4dd323748384bfa248083622aedec982adff3",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [ "mimic-response@1.0.1" ]
+    },
+    "decompress@4.2.0": {
+      "record": {
+        "name": "decompress",
+        "version": "4.2.0",
+        "source":
+          "archive:https://registry.npmjs.org/decompress/-/decompress-4.2.0.tgz#sha1:7aedd85427e5a92dacfe55674a7c505e96d01f9d",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [
+        "decompress-tar@4.1.1", "decompress-tarbz2@4.1.1",
+        "decompress-targz@4.1.1", "decompress-unzip@4.0.1",
+        "graceful-fs@4.1.11", "make-dir@1.3.0", "pify@2.3.0",
+        "strip-dirs@2.1.0"
+      ]
+    },
+    "decode-uri-component@0.2.0": {
+      "record": {
+        "name": "decode-uri-component",
+        "version": "0.2.0",
+        "source":
+          "archive:https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz#sha1:eb3913333458775cb84cd1a1fae062106bb87545",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": []
+    },
+    "decamelize@1.2.0": {
+      "record": {
+        "name": "decamelize",
+        "version": "1.2.0",
+        "source":
+          "archive:https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz#sha1:f6534d15148269b20352e7bee26f501f9a191290",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": []
+    },
+    "debug@3.2.6": {
+      "record": {
+        "name": "debug",
+        "version": "3.2.6",
+        "source":
+          "archive:https://registry.npmjs.org/debug/-/debug-3.2.6.tgz#sha1:e83d17de16d8a7efb7717edbe5fb10135eee629b",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [ "ms@2.1.1" ]
+    },
+    "debug@2.6.9": {
+      "record": {
+        "name": "debug",
+        "version": "2.6.9",
+        "source":
+          "archive:https://registry.npmjs.org/debug/-/debug-2.6.9.tgz#sha1:5d128515df134ff327e90a4c93f4e077a536341f",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [ "ms@2.0.0" ]
+    },
+    "data-urls@1.0.1": {
+      "record": {
+        "name": "data-urls",
+        "version": "1.0.1",
+        "source":
+          "archive:https://registry.npmjs.org/data-urls/-/data-urls-1.0.1.tgz#sha1:d416ac3896918f29ca84d81085bc3705834da579",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [
+        "abab@2.0.0", "whatwg-mimetype@2.2.0", "whatwg-url@7.0.0"
+      ]
+    },
+    "dashdash@1.14.1": {
+      "record": {
+        "name": "dashdash",
+        "version": "1.14.1",
+        "source":
+          "archive:https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz#sha1:853cfa0f7cbe2fed5de20326b8dd581035f6e2f0",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [ "assert-plus@1.0.0" ]
+    },
+    "cssstyle@1.1.1": {
+      "record": {
+        "name": "cssstyle",
+        "version": "1.1.1",
+        "source":
+          "archive:https://registry.npmjs.org/cssstyle/-/cssstyle-1.1.1.tgz#sha1:18b038a9c44d65f7a8e428a653b9f6fe42faf5fb",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [ "cssom@0.3.4" ]
+    },
+    "cssom@0.3.4": {
+      "record": {
+        "name": "cssom",
+        "version": "0.3.4",
+        "source":
+          "archive:https://registry.npmjs.org/cssom/-/cssom-0.3.4.tgz#sha1:8cd52e8a3acfd68d3aed38ee0a640177d2f9d797",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": []
+    },
+    "cross-spawn@5.1.0": {
+      "record": {
+        "name": "cross-spawn",
+        "version": "5.1.0",
+        "source":
+          "archive:https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz#sha1:e8bd0efee58fcff6f8f94510a0a554bbfa235449",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [
+        "lru-cache@4.1.3", "shebang-command@1.2.0", "which@1.3.1"
+      ]
+    },
+    "core-util-is@1.0.2": {
+      "record": {
+        "name": "core-util-is",
+        "version": "1.0.2",
+        "source":
+          "archive:https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz#sha1:b5fd54220aa2bc5ab57aab7140c940754503c1a7",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": []
+    },
+    "core-js@2.5.7": {
+      "record": {
+        "name": "core-js",
+        "version": "2.5.7",
+        "source":
+          "archive:https://registry.npmjs.org/core-js/-/core-js-2.5.7.tgz#sha1:f972608ff0cead68b841a16a932d0b183791814e",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": []
+    },
+    "copy-descriptor@0.1.1": {
+      "record": {
+        "name": "copy-descriptor",
+        "version": "0.1.1",
+        "source":
+          "archive:https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz#sha1:676f6eb3c39997c2ee1ac3a924fd6124748f578d",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": []
+    },
+    "convert-source-map@1.6.0": {
+      "record": {
+        "name": "convert-source-map",
+        "version": "1.6.0",
+        "source":
+          "archive:https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.6.0.tgz#sha1:51b537a8c43e0f04dec1993bffcdd504e758ac20",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [ "safe-buffer@5.1.2" ]
+    },
+    "content-disposition@0.5.2": {
+      "record": {
+        "name": "content-disposition",
+        "version": "0.5.2",
+        "source":
+          "archive:https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.2.tgz#sha1:0cf68bb9ddf5f2be7961c3a85178cb85dba78cb4",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": []
+    },
+    "console-control-strings@1.1.0": {
+      "record": {
+        "name": "console-control-strings",
+        "version": "1.1.0",
+        "source":
+          "archive:https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz#sha1:3d7cf4464db6446ea644bf4b39507f9851008e8e",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": []
+    },
+    "config-chain@1.1.12": {
+      "record": {
+        "name": "config-chain",
+        "version": "1.1.12",
+        "source":
+          "archive:https://registry.npmjs.org/config-chain/-/config-chain-1.1.12.tgz#sha1:0fde8d091200eb5e808caf25fe618c02f48e4efa",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [ "ini@1.3.5", "proto-list@1.2.4" ]
+    },
+    "concat-map@0.0.1": {
+      "record": {
+        "name": "concat-map",
+        "version": "0.0.1",
+        "source":
+          "archive:https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz#sha1:d8a96bd77fd68df7793a73036a3ba0d5405d477b",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": []
+    },
+    "component-emitter@1.2.1": {
+      "record": {
+        "name": "component-emitter",
+        "version": "1.2.1",
+        "source":
+          "archive:https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz#sha1:137918d6d78283f7df7a6b7c5a63e140e69425e6",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": []
+    },
+    "commander@2.17.1": {
+      "record": {
+        "name": "commander",
+        "version": "2.17.1",
+        "source":
+          "archive:https://registry.npmjs.org/commander/-/commander-2.17.1.tgz#sha1:bd77ab7de6de94205ceacc72f1716d29f20a77bf",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": []
+    },
+    "commander@2.8.1": {
+      "record": {
+        "name": "commander",
+        "version": "2.8.1",
+        "source":
+          "archive:http://registry.npmjs.org/commander/-/commander-2.8.1.tgz#sha1:06be367febfda0c330aa1e2a072d3dc9762425d4",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [ "graceful-readlink@1.0.1" ]
+    },
+    "combined-stream@1.0.7": {
+      "record": {
+        "name": "combined-stream",
+        "version": "1.0.7",
+        "source":
+          "archive:https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.7.tgz#sha1:2d1d24317afb8abe95d6d2c0b07b57813539d828",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [ "delayed-stream@1.0.0" ]
+    },
+    "color-name@1.1.3": {
+      "record": {
+        "name": "color-name",
+        "version": "1.1.3",
+        "source":
+          "archive:https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz#sha1:a7d0558bd89c42f795dd42328f740831ca53bc25",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": []
+    },
+    "color-convert@1.9.3": {
+      "record": {
+        "name": "color-convert",
+        "version": "1.9.3",
+        "source":
+          "archive:https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz#sha1:bb71850690e1f136567de629d2d5471deda4c1e8",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [ "color-name@1.1.3" ]
+    },
+    "collection-visit@1.0.0": {
+      "record": {
+        "name": "collection-visit",
+        "version": "1.0.0",
+        "source":
+          "archive:https://registry.npmjs.org/collection-visit/-/collection-visit-1.0.0.tgz#sha1:4bc0373c164bc3291b4d368c829cf1a80a59dca0",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [ "map-visit@1.0.0", "object-visit@1.0.1" ]
+    },
+    "code-point-at@1.1.0": {
+      "record": {
+        "name": "code-point-at",
+        "version": "1.1.0",
+        "source":
+          "archive:https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz#sha1:0d070b4d043a5bea33a2f1a40e2edb3d9a4ccf77",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": []
+    },
+    "co@4.6.0": {
+      "record": {
+        "name": "co",
+        "version": "4.6.0",
+        "source":
+          "archive:https://registry.npmjs.org/co/-/co-4.6.0.tgz#sha1:6ea6bdf3d853ae54ccb8e47bfa0bf3f9031fb184",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": []
+    },
+    "clone-response@1.0.2": {
+      "record": {
+        "name": "clone-response",
+        "version": "1.0.2",
+        "source":
+          "archive:https://registry.npmjs.org/clone-response/-/clone-response-1.0.2.tgz#sha1:d1dc973920314df67fbeb94223b4ee350239e96b",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [ "mimic-response@1.0.1" ]
+    },
+    "cliui@4.1.0": {
+      "record": {
+        "name": "cliui",
+        "version": "4.1.0",
+        "source":
+          "archive:https://registry.npmjs.org/cliui/-/cliui-4.1.0.tgz#sha1:348422dbe82d800b3022eef4f6ac10bf2e4d1b49",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [
+        "string-width@2.1.1", "strip-ansi@4.0.0", "wrap-ansi@2.1.0"
+      ]
+    },
+    "class-utils@0.3.6": {
+      "record": {
+        "name": "class-utils",
+        "version": "0.3.6",
+        "source":
+          "archive:https://registry.npmjs.org/class-utils/-/class-utils-0.3.6.tgz#sha1:f93369ae8b9a7ce02fd41faad0ca83033190c463",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [
+        "arr-union@3.1.0", "define-property@0.2.5", "isobject@3.0.1",
+        "static-extend@0.1.2"
+      ]
+    },
+    "ci-info@1.6.0": {
+      "record": {
+        "name": "ci-info",
+        "version": "1.6.0",
+        "source":
+          "archive:https://registry.npmjs.org/ci-info/-/ci-info-1.6.0.tgz#sha1:2ca20dbb9ceb32d4524a683303313f0304b1e497",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": []
+    },
+    "chownr@1.1.1": {
+      "record": {
+        "name": "chownr",
+        "version": "1.1.1",
+        "source":
+          "archive:https://registry.npmjs.org/chownr/-/chownr-1.1.1.tgz#sha1:54726b8b8fff4df053c42187e801fb4412df1494",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": []
+    },
+    "chalk@2.4.1": {
+      "record": {
+        "name": "chalk",
+        "version": "2.4.1",
+        "source":
+          "archive:https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz#sha1:18c49ab16a037b6eb0152cc83e3471338215b66e",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [
+        "ansi-styles@3.2.1", "escape-string-regexp@1.0.5",
+        "supports-color@5.5.0"
+      ]
+    },
+    "chalk@1.1.3": {
+      "record": {
+        "name": "chalk",
+        "version": "1.1.3",
+        "source":
+          "archive:http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz#sha1:a8115c55e4a702fe4d150abd3872822a7e09fc98",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [
+        "ansi-styles@2.2.1", "escape-string-regexp@1.0.5", "has-ansi@2.0.0",
+        "strip-ansi@3.0.1", "supports-color@2.0.0"
+      ]
+    },
+    "caw@2.0.1": {
+      "record": {
+        "name": "caw",
+        "version": "2.0.1",
+        "source":
+          "archive:https://registry.npmjs.org/caw/-/caw-2.0.1.tgz#sha1:6c3ca071fc194720883c2dc5da9b074bfc7e9e95",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [
+        "get-proxy@2.1.0", "isurl@1.0.0", "tunnel-agent@0.6.0",
+        "url-to-options@1.0.1"
+      ]
+    },
+    "caseless@0.12.0": {
+      "record": {
+        "name": "caseless",
+        "version": "0.12.0",
+        "source":
+          "archive:https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz#sha1:1b681c21ff84033c826543090689420d187151dc",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": []
+    },
+    "capture-exit@1.2.0": {
+      "record": {
+        "name": "capture-exit",
+        "version": "1.2.0",
+        "source":
+          "archive:https://registry.npmjs.org/capture-exit/-/capture-exit-1.2.0.tgz#sha1:1c5fcc489fd0ab00d4f1ac7ae1072e3173fbab6f",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [ "rsvp@3.6.2" ]
+    },
+    "camelcase@4.1.0": {
+      "record": {
+        "name": "camelcase",
+        "version": "4.1.0",
+        "source":
+          "archive:https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz#sha1:d545635be1e33c542649c69173e5de6acfae34dd",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": []
+    },
+    "callsites@2.0.0": {
+      "record": {
+        "name": "callsites",
+        "version": "2.0.0",
+        "source":
+          "archive:https://registry.npmjs.org/callsites/-/callsites-2.0.0.tgz#sha1:06eb84f00eea413da86affefacbffb36093b3c50",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": []
+    },
+    "cacheable-request@2.1.4": {
+      "record": {
+        "name": "cacheable-request",
+        "version": "2.1.4",
+        "source":
+          "archive:https://registry.npmjs.org/cacheable-request/-/cacheable-request-2.1.4.tgz#sha1:0d808801b6342ad33c91df9d0b44dc09b91e5c3d",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [
+        "clone-response@1.0.2", "get-stream@3.0.0",
+        "http-cache-semantics@3.8.1", "keyv@3.0.0", "lowercase-keys@1.0.0",
+        "normalize-url@2.0.1", "responselike@1.0.2"
+      ]
+    },
+    "cache-base@1.0.1": {
+      "record": {
+        "name": "cache-base",
+        "version": "1.0.1",
+        "source":
+          "archive:https://registry.npmjs.org/cache-base/-/cache-base-1.0.1.tgz#sha1:0a7f46416831c8b662ee36fe4e7c59d76f666ab2",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [
+        "collection-visit@1.0.0", "component-emitter@1.2.1",
+        "get-value@2.0.6", "has-value@1.0.0", "isobject@3.0.1",
+        "set-value@2.0.0", "to-object-path@0.3.0", "union-value@1.0.0",
+        "unset-value@1.0.0"
+      ]
+    },
+    "builtin-modules@1.1.1": {
+      "record": {
+        "name": "builtin-modules",
+        "version": "1.1.1",
+        "source":
+          "archive:https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz#sha1:270f076c5a72c02f5b65a47df94c5fe3a278892f",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": []
+    },
+    "buffer-from@1.1.1": {
+      "record": {
+        "name": "buffer-from",
+        "version": "1.1.1",
+        "source":
+          "archive:https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz#sha1:32713bc028f75c02fdb710d7c7bcec1f2c6070ef",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": []
+    },
+    "buffer-fill@1.0.0": {
+      "record": {
+        "name": "buffer-fill",
+        "version": "1.0.0",
+        "source":
+          "archive:https://registry.npmjs.org/buffer-fill/-/buffer-fill-1.0.0.tgz#sha1:f8f78b76789888ef39f205cd637f68e702122b2c",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": []
+    },
+    "buffer-crc32@0.2.13": {
+      "record": {
+        "name": "buffer-crc32",
+        "version": "0.2.13",
+        "source":
+          "archive:https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz#sha1:0d333e3f00eac50aa1454abd30ef8c2a5d9a7242",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": []
+    },
+    "buffer-alloc-unsafe@1.1.0": {
+      "record": {
+        "name": "buffer-alloc-unsafe",
+        "version": "1.1.0",
+        "source":
+          "archive:https://registry.npmjs.org/buffer-alloc-unsafe/-/buffer-alloc-unsafe-1.1.0.tgz#sha1:bd7dc26ae2972d0eda253be061dba992349c19f0",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": []
+    },
+    "buffer-alloc@1.2.0": {
+      "record": {
+        "name": "buffer-alloc",
+        "version": "1.2.0",
+        "source":
+          "archive:https://registry.npmjs.org/buffer-alloc/-/buffer-alloc-1.2.0.tgz#sha1:890dd90d923a873e08e10e5fd51a57e5b7cce0ec",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [ "buffer-alloc-unsafe@1.1.0", "buffer-fill@1.0.0" ]
+    },
+    "buffer@3.6.0": {
+      "record": {
+        "name": "buffer",
+        "version": "3.6.0",
+        "source":
+          "archive:http://registry.npmjs.org/buffer/-/buffer-3.6.0.tgz#sha1:a72c936f77b96bf52f5f7e7b467180628551defb",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [
+        "base64-js@0.0.8", "ieee754@1.1.12", "isarray@1.0.0"
+      ]
+    },
+    "bser@2.0.0": {
+      "record": {
+        "name": "bser",
+        "version": "2.0.0",
+        "source":
+          "archive:https://registry.npmjs.org/bser/-/bser-2.0.0.tgz#sha1:9ac78d3ed5d915804fd87acb158bc797147a1719",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [ "node-int64@0.4.0" ]
+    },
+    "browser-resolve@1.11.3": {
+      "record": {
+        "name": "browser-resolve",
+        "version": "1.11.3",
+        "source":
+          "archive:https://registry.npmjs.org/browser-resolve/-/browser-resolve-1.11.3.tgz#sha1:9b7cbb3d0f510e4cb86bdbd796124d28b5890af6",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [ "resolve@1.1.7" ]
+    },
+    "browser-process-hrtime@0.1.3": {
+      "record": {
+        "name": "browser-process-hrtime",
+        "version": "0.1.3",
+        "source":
+          "archive:https://registry.npmjs.org/browser-process-hrtime/-/browser-process-hrtime-0.1.3.tgz#sha1:616f00faef1df7ec1b5bf9cfe2bdc3170f26c7b4",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": []
+    },
+    "braces@2.3.2": {
+      "record": {
+        "name": "braces",
+        "version": "2.3.2",
+        "source":
+          "archive:https://registry.npmjs.org/braces/-/braces-2.3.2.tgz#sha1:5979fd3f14cd531565e5fa2df1abfff1dfaee729",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [
+        "arr-flatten@1.1.0", "array-unique@0.3.2", "extend-shallow@2.0.1",
+        "fill-range@4.0.0", "isobject@3.0.1", "repeat-element@1.1.3",
+        "snapdragon@0.8.2", "snapdragon-node@2.1.1", "split-string@3.1.0",
+        "to-regex@3.0.2"
+      ]
+    },
+    "braces@1.8.5": {
+      "record": {
+        "name": "braces",
+        "version": "1.8.5",
+        "source":
+          "archive:https://registry.npmjs.org/braces/-/braces-1.8.5.tgz#sha1:ba77962e12dff969d6b76711e914b737857bf6a7",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [
+        "expand-range@1.8.2", "preserve@0.2.0", "repeat-element@1.1.3"
+      ]
+    },
+    "brace-expansion@1.1.11": {
+      "record": {
+        "name": "brace-expansion",
+        "version": "1.1.11",
+        "source":
+          "archive:https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz#sha1:3c7fcbf529d87226f3d2f52b966ff5271eb441dd",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [ "balanced-match@1.0.0", "concat-map@0.0.1" ]
+    },
+    "bl@1.2.2": {
+      "record": {
+        "name": "bl",
+        "version": "1.2.2",
+        "source":
+          "archive:http://registry.npmjs.org/bl/-/bl-1.2.2.tgz#sha1:a160911717103c07410cef63ef51b397c025af9c",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [ "readable-stream@2.3.6", "safe-buffer@5.1.2" ]
+    },
+    "bcrypt-pbkdf@1.0.2": {
+      "record": {
+        "name": "bcrypt-pbkdf",
+        "version": "1.0.2",
+        "source":
+          "archive:https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz#sha1:a4301d389b6a43f9b67ff3ca11a3f6637e360e9e",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [ "tweetnacl@0.14.5" ]
+    },
+    "base64-js@0.0.8": {
+      "record": {
+        "name": "base64-js",
+        "version": "0.0.8",
+        "source":
+          "archive:https://registry.npmjs.org/base64-js/-/base64-js-0.0.8.tgz#sha1:1101e9544f4a76b1bc3b26d452ca96d7a35e7978",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": []
+    },
+    "base@0.11.2": {
+      "record": {
+        "name": "base",
+        "version": "0.11.2",
+        "source":
+          "archive:https://registry.npmjs.org/base/-/base-0.11.2.tgz#sha1:7bde5ced145b6d551a90db87f83c558b4eb48a8f",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [
+        "cache-base@1.0.1", "class-utils@0.3.6", "component-emitter@1.2.1",
+        "define-property@1.0.0", "isobject@3.0.1", "mixin-deep@1.3.1",
+        "pascalcase@0.1.1"
+      ]
+    },
+    "balanced-match@1.0.0": {
+      "record": {
+        "name": "balanced-match",
+        "version": "1.0.0",
+        "source":
+          "archive:https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz#sha1:89b4d199ab2bee49de164ea02b89ce462d71b767",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": []
+    },
+    "babylon@6.18.0": {
+      "record": {
+        "name": "babylon",
+        "version": "6.18.0",
+        "source":
+          "archive:https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz#sha1:af2f3b88fa6f5c1e4c634d1a0f8eac4f55b395e3",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": []
+    },
+    "babel-types@6.26.0": {
+      "record": {
+        "name": "babel-types",
+        "version": "6.26.0",
+        "source":
+          "archive:https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz#sha1:a3b073f94ab49eb6fa55cd65227a334380632497",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [
+        "babel-runtime@6.26.0", "esutils@2.0.2", "lodash@4.17.11",
+        "to-fast-properties@1.0.3"
+      ]
+    },
+    "babel-traverse@6.26.0": {
+      "record": {
+        "name": "babel-traverse",
+        "version": "6.26.0",
+        "source":
+          "archive:https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.26.0.tgz#sha1:46a9cbd7edcc62c8e5c064e2d2d8d0f4035766ee",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [
+        "babel-code-frame@6.26.0", "babel-messages@6.23.0",
+        "babel-runtime@6.26.0", "babel-types@6.26.0", "babylon@6.18.0",
+        "debug@2.6.9", "globals@9.18.0", "invariant@2.2.4", "lodash@4.17.11"
+      ]
+    },
+    "babel-template@6.26.0": {
+      "record": {
+        "name": "babel-template",
+        "version": "6.26.0",
+        "source":
+          "archive:https://registry.npmjs.org/babel-template/-/babel-template-6.26.0.tgz#sha1:de03e2d16396b069f46dd9fff8521fb1a0e35e02",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [
+        "babel-runtime@6.26.0", "babel-traverse@6.26.0",
+        "babel-types@6.26.0", "babylon@6.18.0", "lodash@4.17.11"
+      ]
+    },
+    "babel-runtime@6.26.0": {
+      "record": {
+        "name": "babel-runtime",
+        "version": "6.26.0",
+        "source":
+          "archive:https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz#sha1:965c7058668e82b55d7bfe04ff2337bc8b5647fe",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [ "core-js@2.5.7", "regenerator-runtime@0.11.1" ]
+    },
+    "babel-register@6.26.0": {
+      "record": {
+        "name": "babel-register",
+        "version": "6.26.0",
+        "source":
+          "archive:https://registry.npmjs.org/babel-register/-/babel-register-6.26.0.tgz#sha1:6ed021173e2fcb486d7acb45c6009a856f647071",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [
+        "babel-core@6.26.3", "babel-runtime@6.26.0", "core-js@2.5.7",
+        "home-or-tmp@2.0.0", "lodash@4.17.11", "mkdirp@0.5.1",
+        "source-map-support@0.4.18"
+      ]
+    },
+    "babel-preset-jest@23.2.0": {
+      "record": {
+        "name": "babel-preset-jest",
+        "version": "23.2.0",
+        "source":
+          "archive:https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-23.2.0.tgz#sha1:8ec7a03a138f001a1a8fb1e8113652bf1a55da46",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [
+        "babel-plugin-jest-hoist@23.2.0",
+        "babel-plugin-syntax-object-rest-spread@6.13.0"
+      ]
+    },
+    "babel-plugin-syntax-object-rest-spread@6.13.0": {
+      "record": {
+        "name": "babel-plugin-syntax-object-rest-spread",
+        "version": "6.13.0",
+        "source":
+          "archive:http://registry.npmjs.org/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-6.13.0.tgz#sha1:fd6536f2bce13836ffa3a5458c4903a597bb3bf5",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": []
+    },
+    "babel-plugin-jest-hoist@23.2.0": {
+      "record": {
+        "name": "babel-plugin-jest-hoist",
+        "version": "23.2.0",
+        "source":
+          "archive:https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-23.2.0.tgz#sha1:e61fae05a1ca8801aadee57a6d66b8cefaf44167",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": []
+    },
+    "babel-plugin-istanbul@4.1.6": {
+      "record": {
+        "name": "babel-plugin-istanbul",
+        "version": "4.1.6",
+        "source":
+          "archive:http://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-4.1.6.tgz#sha1:36c59b2192efce81c5b378321b74175add1c9a45",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [
+        "babel-plugin-syntax-object-rest-spread@6.13.0", "find-up@2.1.0",
+        "istanbul-lib-instrument@1.10.2", "test-exclude@4.2.3"
+      ]
+    },
+    "babel-messages@6.23.0": {
+      "record": {
+        "name": "babel-messages",
+        "version": "6.23.0",
+        "source":
+          "archive:https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz#sha1:f3cdf4703858035b2a2951c6ec5edf6c62f2630e",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [ "babel-runtime@6.26.0" ]
+    },
+    "babel-jest@23.6.0": {
+      "record": {
+        "name": "babel-jest",
+        "version": "23.6.0",
+        "source":
+          "archive:https://registry.npmjs.org/babel-jest/-/babel-jest-23.6.0.tgz#sha1:a644232366557a2240a0c083da6b25786185a2f1",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [
+        "babel-plugin-istanbul@4.1.6", "babel-preset-jest@23.2.0"
+      ]
+    },
+    "babel-helpers@6.24.1": {
+      "record": {
+        "name": "babel-helpers",
+        "version": "6.24.1",
+        "source":
+          "archive:https://registry.npmjs.org/babel-helpers/-/babel-helpers-6.24.1.tgz#sha1:3471de9caec388e5c850e597e58a26ddf37602b2",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [ "babel-runtime@6.26.0", "babel-template@6.26.0" ]
+    },
+    "babel-generator@6.26.1": {
+      "record": {
+        "name": "babel-generator",
+        "version": "6.26.1",
+        "source":
+          "archive:https://registry.npmjs.org/babel-generator/-/babel-generator-6.26.1.tgz#sha1:1844408d3b8f0d35a404ea7ac180f087a601bd90",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [
+        "babel-messages@6.23.0", "babel-runtime@6.26.0",
+        "babel-types@6.26.0", "detect-indent@4.0.0", "jsesc@1.3.0",
+        "lodash@4.17.11", "source-map@0.5.7", "trim-right@1.0.1"
+      ]
+    },
+    "babel-core@6.26.3": {
+      "record": {
+        "name": "babel-core",
+        "version": "6.26.3",
+        "source":
+          "archive:https://registry.npmjs.org/babel-core/-/babel-core-6.26.3.tgz#sha1:b2e2f09e342d0f0c88e2f02e067794125e75c207",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [
+        "babel-code-frame@6.26.0", "babel-generator@6.26.1",
+        "babel-helpers@6.24.1", "babel-messages@6.23.0",
+        "babel-register@6.26.0", "babel-runtime@6.26.0",
+        "babel-template@6.26.0", "babel-traverse@6.26.0",
+        "babel-types@6.26.0", "babylon@6.18.0", "convert-source-map@1.6.0",
+        "debug@2.6.9", "json5@0.5.1", "lodash@4.17.11", "minimatch@3.0.4",
+        "path-is-absolute@1.0.1", "private@0.1.8", "slash@1.0.0",
+        "source-map@0.5.7"
+      ]
+    },
+    "babel-code-frame@6.26.0": {
+      "record": {
+        "name": "babel-code-frame",
+        "version": "6.26.0",
+        "source":
+          "archive:https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz#sha1:63fd43f7dc1e3bb7ce35947db8fe369a3f58c74b",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [ "chalk@1.1.3", "esutils@2.0.2", "js-tokens@3.0.2" ]
+    },
+    "aws4@1.8.0": {
+      "record": {
+        "name": "aws4",
+        "version": "1.8.0",
+        "source":
+          "archive:https://registry.npmjs.org/aws4/-/aws4-1.8.0.tgz#sha1:f0e003d9ca9e7f59c7a508945d7b2ef9a04a542f",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": []
+    },
+    "aws-sign2@0.7.0": {
+      "record": {
+        "name": "aws-sign2",
+        "version": "0.7.0",
+        "source":
+          "archive:https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz#sha1:b46e890934a9591f2d2f6f86d7e6a9f1b3fe76a8",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": []
+    },
+    "atob@2.1.2": {
+      "record": {
+        "name": "atob",
+        "version": "2.1.2",
+        "source":
+          "archive:https://registry.npmjs.org/atob/-/atob-2.1.2.tgz#sha1:6d9517eb9e030d2436666651e86bd9f6f13533c9",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": []
+    },
+    "asynckit@0.4.0": {
+      "record": {
+        "name": "asynckit",
+        "version": "0.4.0",
+        "source":
+          "archive:https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz#sha1:c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": []
+    },
+    "async-limiter@1.0.0": {
+      "record": {
+        "name": "async-limiter",
+        "version": "1.0.0",
+        "source":
+          "archive:https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.0.tgz#sha1:78faed8c3d074ab81f22b4e985d79e8738f720f8",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": []
+    },
+    "async@2.6.1": {
+      "record": {
+        "name": "async",
+        "version": "2.6.1",
+        "source":
+          "archive:https://registry.npmjs.org/async/-/async-2.6.1.tgz#sha1:b245a23ca71930044ec53fa46aa00a3e87c6a610",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [ "lodash@4.17.11" ]
+    },
+    "astral-regex@1.0.0": {
+      "record": {
+        "name": "astral-regex",
+        "version": "1.0.0",
+        "source":
+          "archive:https://registry.npmjs.org/astral-regex/-/astral-regex-1.0.0.tgz#sha1:6c8c3fb827dd43ee3918f27b82782ab7658a6fd9",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": []
+    },
+    "assign-symbols@1.0.0": {
+      "record": {
+        "name": "assign-symbols",
+        "version": "1.0.0",
+        "source":
+          "archive:https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz#sha1:59667f41fadd4f20ccbc2bb96b8d4f7f78ec0367",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": []
+    },
+    "assert-plus@1.0.0": {
+      "record": {
+        "name": "assert-plus",
+        "version": "1.0.0",
+        "source":
+          "archive:https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz#sha1:f12e0f3c5d77b0b1cdd9146942e4e96c1e4dd525",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": []
+    },
+    "asn1@0.2.4": {
+      "record": {
+        "name": "asn1",
+        "version": "0.2.4",
+        "source":
+          "archive:https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz#sha1:8d2475dfab553bb33e77b54e59e880bb8ce23136",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [ "safer-buffer@2.1.2" ]
+    },
+    "arrify@1.0.1": {
+      "record": {
+        "name": "arrify",
+        "version": "1.0.1",
+        "source":
+          "archive:https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz#sha1:898508da2226f380df904728456849c1501a4b0d",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": []
+    },
+    "array-unique@0.3.2": {
+      "record": {
+        "name": "array-unique",
+        "version": "0.3.2",
+        "source":
+          "archive:https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz#sha1:a894b75d4bc4f6cd679ef3244a9fd8f46ae2d428",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": []
+    },
+    "array-unique@0.2.1": {
+      "record": {
+        "name": "array-unique",
+        "version": "0.2.1",
+        "source":
+          "archive:https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz#sha1:a1d97ccafcbc2625cc70fadceb36a50c58b01a53",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": []
+    },
+    "array-equal@1.0.0": {
+      "record": {
+        "name": "array-equal",
+        "version": "1.0.0",
+        "source":
+          "archive:https://registry.npmjs.org/array-equal/-/array-equal-1.0.0.tgz#sha1:8c2a5ef2472fd9ea742b04c77a75093ba2757c93",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": []
+    },
+    "arr-union@3.1.0": {
+      "record": {
+        "name": "arr-union",
+        "version": "3.1.0",
+        "source":
+          "archive:https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz#sha1:e39b09aea9def866a8f206e288af63919bae39c4",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": []
+    },
+    "arr-flatten@1.1.0": {
+      "record": {
+        "name": "arr-flatten",
+        "version": "1.1.0",
+        "source":
+          "archive:https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz#sha1:36048bbff4e7b47e136644316c99669ea5ae91f1",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": []
+    },
+    "arr-diff@4.0.0": {
+      "record": {
+        "name": "arr-diff",
+        "version": "4.0.0",
+        "source":
+          "archive:https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz#sha1:d6461074febfec71e7e15235761a329a5dc7c520",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": []
+    },
+    "arr-diff@2.0.0": {
+      "record": {
+        "name": "arr-diff",
+        "version": "2.0.0",
+        "source":
+          "archive:https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz#sha1:8f3b827f955a8bd669697e4a4256ac3ceae356cf",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [ "arr-flatten@1.1.0" ]
+    },
+    "argparse@1.0.10": {
+      "record": {
+        "name": "argparse",
+        "version": "1.0.10",
+        "source":
+          "archive:https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz#sha1:bcd6791ea5ae09725e17e5ad988134cd40b3d911",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [ "sprintf-js@1.0.3" ]
+    },
+    "are-we-there-yet@1.1.5": {
+      "record": {
+        "name": "are-we-there-yet",
+        "version": "1.1.5",
+        "source":
+          "archive:https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.5.tgz#sha1:4b35c2944f062a8bfcda66410760350fe9ddfc21",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [ "delegates@1.0.0", "readable-stream@2.3.6" ]
+    },
+    "archive-type@4.0.0": {
+      "record": {
+        "name": "archive-type",
+        "version": "4.0.0",
+        "source":
+          "archive:https://registry.npmjs.org/archive-type/-/archive-type-4.0.0.tgz#sha1:f92e72233056dfc6969472749c267bdb046b1d70",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [ "file-type@4.4.0" ]
+    },
+    "aproba@1.2.0": {
+      "record": {
+        "name": "aproba",
+        "version": "1.2.0",
+        "source":
+          "archive:https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz#sha1:6802e6264efd18c790a1b0d517f0f2627bf2c94a",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": []
+    },
+    "append-transform@0.4.0": {
+      "record": {
+        "name": "append-transform",
+        "version": "0.4.0",
+        "source":
+          "archive:https://registry.npmjs.org/append-transform/-/append-transform-0.4.0.tgz#sha1:d76ebf8ca94d276e247a36bad44a4b74ab611991",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [ "default-require-extensions@1.0.0" ]
+    },
+    "anymatch@2.0.0": {
+      "record": {
+        "name": "anymatch",
+        "version": "2.0.0",
+        "source":
+          "archive:https://registry.npmjs.org/anymatch/-/anymatch-2.0.0.tgz#sha1:bcb24b4f37934d9aa7ac17b4adaf89e7c76ef2eb",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [ "micromatch@3.1.10", "normalize-path@2.1.1" ]
+    },
+    "ansi-styles@3.2.1": {
+      "record": {
+        "name": "ansi-styles",
+        "version": "3.2.1",
+        "source":
+          "archive:https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz#sha1:41fbb20243e50b12be0f04b8dedbf07520ce841d",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [ "color-convert@1.9.3" ]
+    },
+    "ansi-styles@2.2.1": {
+      "record": {
+        "name": "ansi-styles",
+        "version": "2.2.1",
+        "source":
+          "archive:https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz#sha1:b432dd3358b634cf75e1e4664368240533c1ddbe",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": []
+    },
+    "ansi-regex@3.0.0": {
+      "record": {
+        "name": "ansi-regex",
+        "version": "3.0.0",
+        "source":
+          "archive:https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz#sha1:ed0317c322064f79466c02966bddb605ab37d998",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": []
+    },
+    "ansi-regex@2.1.1": {
+      "record": {
+        "name": "ansi-regex",
+        "version": "2.1.1",
+        "source":
+          "archive:https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz#sha1:c3b33ab5ee360d86e0e628f0468ae7ef27d654df",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": []
+    },
+    "ansi-escapes@3.1.0": {
+      "record": {
+        "name": "ansi-escapes",
+        "version": "3.1.0",
+        "source":
+          "archive:https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.1.0.tgz#sha1:f73207bb81207d75fd6c83f125af26eea378ca30",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": []
+    },
+    "ajv@5.5.2": {
+      "record": {
+        "name": "ajv",
+        "version": "5.5.2",
+        "source":
+          "archive:https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz#sha1:73b5eeca3fab653e3d3f9422b341ad42205dc965",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [
+        "co@4.6.0", "fast-deep-equal@1.1.0",
+        "fast-json-stable-stringify@2.0.0", "json-schema-traverse@0.3.1"
+      ]
+    },
+    "acorn-walk@6.1.0": {
+      "record": {
+        "name": "acorn-walk",
+        "version": "6.1.0",
+        "source":
+          "archive:https://registry.npmjs.org/acorn-walk/-/acorn-walk-6.1.0.tgz#sha1:c957f4a1460da46af4a0388ce28b4c99355b0cbc",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": []
+    },
+    "acorn-globals@4.3.0": {
+      "record": {
+        "name": "acorn-globals",
+        "version": "4.3.0",
+        "source":
+          "archive:https://registry.npmjs.org/acorn-globals/-/acorn-globals-4.3.0.tgz#sha1:e3b6f8da3c1552a95ae627571f7dd6923bb54103",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [ "acorn@6.0.2", "acorn-walk@6.1.0" ]
+    },
+    "acorn@6.0.2": {
+      "record": {
+        "name": "acorn",
+        "version": "6.0.2",
+        "source":
+          "archive:https://registry.npmjs.org/acorn/-/acorn-6.0.2.tgz#sha1:6a459041c320ab17592c6317abbfdf4bbaa98ca4",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": []
+    },
+    "acorn@5.7.3": {
+      "record": {
+        "name": "acorn",
+        "version": "5.7.3",
+        "source":
+          "archive:https://registry.npmjs.org/acorn/-/acorn-5.7.3.tgz#sha1:67aa231bf8812974b85235a96771eb6bd07ea279",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": []
+    },
+    "abbrev@1.1.1": {
+      "record": {
+        "name": "abbrev",
+        "version": "1.1.1",
+        "source":
+          "archive:https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz#sha1:f8f2c887ad10bf67f634f005b6987fed3179aac8",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": []
+    },
+    "abab@2.0.0": {
+      "record": {
+        "name": "abab",
+        "version": "2.0.0",
+        "source":
+          "archive:https://registry.npmjs.org/abab/-/abab-2.0.0.tgz#sha1:aba0ab4c5eee2d4c79d3487d85450fb2376ebb0f",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": []
+    },
+    "@sindresorhus/is@0.7.0": {
+      "record": {
+        "name": "@sindresorhus/is",
+        "version": "0.7.0",
+        "source":
+          "archive:https://registry.npmjs.org/@sindresorhus/is/-/is-0.7.0.tgz#sha1:9a06f4f137ee84d7df0460c1fdb1135ffa6c50fd",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": []
+    },
+    "@babel/highlight@7.0.0": {
+      "record": {
+        "name": "@babel/highlight",
+        "version": "7.0.0",
+        "source":
+          "archive:https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0.tgz#sha1:f710c38c8d458e6dd9a201afb637fcb781ce99e4",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [ "chalk@2.4.1", "esutils@2.0.2", "js-tokens@4.0.0" ]
+    },
+    "@babel/code-frame@7.0.0": {
+      "record": {
+        "name": "@babel/code-frame",
+        "version": "7.0.0",
+        "source":
+          "archive:https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0.tgz#sha1:06e2ab19bdb535385559aabb5ba59729482800f8",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": [ "@babel/highlight@7.0.0" ]
+    }
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "esy-bash",
-  "version": "0.1.7",
+  "version": "0.1.24",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -27,7 +27,8 @@
     "@sindresorhus/is": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-0.7.0.tgz",
-      "integrity": "sha512-ONhaKPIufzzrlNbqtWFFd+jlnemX6lJAgq9ZeiZtS7I1PIf/la7CW4m83rTXRnVnsMbW2k56pGYu7AUFJD9Pow=="
+      "integrity": "sha512-ONhaKPIufzzrlNbqtWFFd+jlnemX6lJAgq9ZeiZtS7I1PIf/la7CW4m83rTXRnVnsMbW2k56pGYu7AUFJD9Pow==",
+      "dev": true
     },
     "abab": {
       "version": "1.0.4",
@@ -552,7 +553,8 @@
     "base64-js": {
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-0.0.8.tgz",
-      "integrity": "sha1-EQHpVE9KdrG8OybUUsqW16NeeXg="
+      "integrity": "sha1-EQHpVE9KdrG8OybUUsqW16NeeXg=",
+      "dev": true
     },
     "bcrypt-pbkdf": {
       "version": "1.0.1",
@@ -568,6 +570,7 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/bl/-/bl-1.2.2.tgz",
       "integrity": "sha512-e8tQYnZodmebYDWGH7KMRvtzKXaJHx3BbilrgZCfvyLUYdKpK1t5PSPmpkny/SgiTSCnjfLW7v5rlONXVFkQEA==",
+      "dev": true,
       "requires": {
         "readable-stream": "2.3.6",
         "safe-buffer": "5.1.2"
@@ -640,6 +643,7 @@
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/buffer/-/buffer-3.6.0.tgz",
       "integrity": "sha1-pyyTb3e5a/UvX357RnGAYoVR3vs=",
+      "dev": true,
       "requires": {
         "base64-js": "0.0.8",
         "ieee754": "1.1.12",
@@ -650,6 +654,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/buffer-alloc/-/buffer-alloc-1.2.0.tgz",
       "integrity": "sha512-CFsHQgjtW1UChdXgbyJGtnm+O/uLQeZdtbDo8mfUgYXCHSM1wgrVxXm6bSyrUuErEb+4sYVGCzASBRot7zyrow==",
+      "dev": true,
       "requires": {
         "buffer-alloc-unsafe": "1.1.0",
         "buffer-fill": "1.0.0"
@@ -658,17 +663,20 @@
     "buffer-alloc-unsafe": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/buffer-alloc-unsafe/-/buffer-alloc-unsafe-1.1.0.tgz",
-      "integrity": "sha512-TEM2iMIEQdJ2yjPJoSIsldnleVaAk1oW3DBVUykyOLsEsFmEc9kn+SFFPz+gl54KQNxlDnAwCXosOS9Okx2xAg=="
+      "integrity": "sha512-TEM2iMIEQdJ2yjPJoSIsldnleVaAk1oW3DBVUykyOLsEsFmEc9kn+SFFPz+gl54KQNxlDnAwCXosOS9Okx2xAg==",
+      "dev": true
     },
     "buffer-crc32": {
       "version": "0.2.13",
       "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
-      "integrity": "sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI="
+      "integrity": "sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI=",
+      "dev": true
     },
     "buffer-fill": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/buffer-fill/-/buffer-fill-1.0.0.tgz",
-      "integrity": "sha1-+PeLdniYiO858gXNY39o5wISKyw="
+      "integrity": "sha1-+PeLdniYiO858gXNY39o5wISKyw=",
+      "dev": true
     },
     "buffer-from": {
       "version": "1.1.0",
@@ -703,6 +711,7 @@
       "version": "2.1.4",
       "resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-2.1.4.tgz",
       "integrity": "sha1-DYCIAbY0KtM8kd+dC0TcCbkeXD0=",
+      "dev": true,
       "requires": {
         "clone-response": "1.0.2",
         "get-stream": "3.0.0",
@@ -716,7 +725,8 @@
         "lowercase-keys": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.0.tgz",
-          "integrity": "sha1-TjNms55/VFfjXxMkvfb4jQv8cwY="
+          "integrity": "sha1-TjNms55/VFfjXxMkvfb4jQv8cwY=",
+          "dev": true
         }
       }
     },
@@ -752,6 +762,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/caw/-/caw-2.0.1.tgz",
       "integrity": "sha512-Cg8/ZSBEa8ZVY9HspcGUYaK63d/bN7rqS3CYCzEGUxuYv6UlmcjzDUz2fCFFHyTvUW5Pk0I+3hkA3iXlIj6guA==",
+      "dev": true,
       "requires": {
         "get-proxy": "2.1.0",
         "isurl": "1.0.0",
@@ -835,6 +846,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/clone-response/-/clone-response-1.0.2.tgz",
       "integrity": "sha1-0dyXOSAxTfZ/vrlCI7TuNQI56Ws=",
+      "dev": true,
       "requires": {
         "mimic-response": "1.0.0"
       }
@@ -889,6 +901,7 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.8.1.tgz",
       "integrity": "sha1-Br42f+v9oMMwqh4qBy09yXYkJdQ=",
+      "dev": true,
       "requires": {
         "graceful-readlink": "1.0.1"
       }
@@ -915,6 +928,7 @@
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.11.tgz",
       "integrity": "sha1-q6CXR9++TD5w52am5BWG4YWfxvI=",
+      "dev": true,
       "requires": {
         "ini": "1.3.5",
         "proto-list": "1.2.4"
@@ -923,7 +937,8 @@
     "content-disposition": {
       "version": "0.5.2",
       "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.2.tgz",
-      "integrity": "sha1-DPaLud318r55YcOoUXjLhdunjLQ="
+      "integrity": "sha1-DPaLud318r55YcOoUXjLhdunjLQ=",
+      "dev": true
     },
     "convert-source-map": {
       "version": "1.5.1",
@@ -946,7 +961,8 @@
     "core-util-is": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+      "dev": true
     },
     "cross-spawn": {
       "version": "5.1.0",
@@ -1012,12 +1028,14 @@
     "decode-uri-component": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
-      "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU="
+      "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
+      "dev": true
     },
     "decompress": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/decompress/-/decompress-4.2.0.tgz",
       "integrity": "sha1-eu3YVCflqS2s/lVnSnxQXpbQH50=",
+      "dev": true,
       "requires": {
         "decompress-tar": "4.1.1",
         "decompress-tarbz2": "4.1.1",
@@ -1032,7 +1050,8 @@
         "pify": {
           "version": "2.3.0",
           "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
+          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+          "dev": true
         }
       }
     },
@@ -1040,6 +1059,7 @@
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-3.3.0.tgz",
       "integrity": "sha1-gKTdMjdIOEv6JICDYirt7Jgq3/M=",
+      "dev": true,
       "requires": {
         "mimic-response": "1.0.0"
       }
@@ -1048,6 +1068,7 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/decompress-tar/-/decompress-tar-4.1.1.tgz",
       "integrity": "sha512-JdJMaCrGpB5fESVyxwpCx4Jdj2AagLmv3y58Qy4GE6HMVjWz1FeVQk1Ct4Kye7PftcdOo/7U7UKzYBJgqnGeUQ==",
+      "dev": true,
       "requires": {
         "file-type": "5.2.0",
         "is-stream": "1.1.0",
@@ -1057,7 +1078,8 @@
         "file-type": {
           "version": "5.2.0",
           "resolved": "https://registry.npmjs.org/file-type/-/file-type-5.2.0.tgz",
-          "integrity": "sha1-LdvqfHP/42No365J3DOMBYwritY="
+          "integrity": "sha1-LdvqfHP/42No365J3DOMBYwritY=",
+          "dev": true
         }
       }
     },
@@ -1065,6 +1087,7 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/decompress-tarbz2/-/decompress-tarbz2-4.1.1.tgz",
       "integrity": "sha512-s88xLzf1r81ICXLAVQVzaN6ZmX4A6U4z2nMbOwobxkLoIIfjVMBg7TeguTUXkKeXni795B6y5rnvDw7rxhAq9A==",
+      "dev": true,
       "requires": {
         "decompress-tar": "4.1.1",
         "file-type": "6.2.0",
@@ -1076,7 +1099,8 @@
         "file-type": {
           "version": "6.2.0",
           "resolved": "https://registry.npmjs.org/file-type/-/file-type-6.2.0.tgz",
-          "integrity": "sha512-YPcTBDV+2Tm0VqjybVd32MHdlEGAtuxS3VAYsumFokDSMG+ROT5wawGlnHDoz7bfMcMDt9hxuXvXwoKUx2fkOg=="
+          "integrity": "sha512-YPcTBDV+2Tm0VqjybVd32MHdlEGAtuxS3VAYsumFokDSMG+ROT5wawGlnHDoz7bfMcMDt9hxuXvXwoKUx2fkOg==",
+          "dev": true
         }
       }
     },
@@ -1084,6 +1108,7 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/decompress-targz/-/decompress-targz-4.1.1.tgz",
       "integrity": "sha512-4z81Znfr6chWnRDNfFNqLwPvm4db3WuZkqV+UgXQzSngG3CEKdBkw5jrv3axjjL96glyiiKjsxJG3X6WBZwX3w==",
+      "dev": true,
       "requires": {
         "decompress-tar": "4.1.1",
         "file-type": "5.2.0",
@@ -1093,7 +1118,8 @@
         "file-type": {
           "version": "5.2.0",
           "resolved": "https://registry.npmjs.org/file-type/-/file-type-5.2.0.tgz",
-          "integrity": "sha1-LdvqfHP/42No365J3DOMBYwritY="
+          "integrity": "sha1-LdvqfHP/42No365J3DOMBYwritY=",
+          "dev": true
         }
       }
     },
@@ -1101,6 +1127,7 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/decompress-unzip/-/decompress-unzip-4.0.1.tgz",
       "integrity": "sha1-3qrM39FK6vhVePczroIQ+bSEj2k=",
+      "dev": true,
       "requires": {
         "file-type": "3.9.0",
         "get-stream": "2.3.1",
@@ -1111,12 +1138,14 @@
         "file-type": {
           "version": "3.9.0",
           "resolved": "https://registry.npmjs.org/file-type/-/file-type-3.9.0.tgz",
-          "integrity": "sha1-JXoHg4TR24CHvESdEH1SpSZyuek="
+          "integrity": "sha1-JXoHg4TR24CHvESdEH1SpSZyuek=",
+          "dev": true
         },
         "get-stream": {
           "version": "2.3.1",
           "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-2.3.1.tgz",
           "integrity": "sha1-Xzj5PzRgCWZu4BUKBUFn+Rvdld4=",
+          "dev": true,
           "requires": {
             "object-assign": "4.1.1",
             "pinkie-promise": "2.0.1"
@@ -1125,7 +1154,8 @@
         "pify": {
           "version": "2.3.0",
           "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
+          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+          "dev": true
         }
       }
     },
@@ -1241,6 +1271,7 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/download/-/download-7.0.0.tgz",
       "integrity": "sha512-0Fe/CAjKycx12IG9We9gYlLP03BEcWTpttg7P5mwfOiQTg584kpuHqP7F61RkUJM+mfEdEU9TJonm0PJp5rQLw==",
+      "dev": true,
       "requires": {
         "caw": "2.0.1",
         "content-disposition": "0.5.2",
@@ -1258,7 +1289,8 @@
     "duplexer3": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.4.tgz",
-      "integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI="
+      "integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI=",
+      "dev": true
     },
     "ecc-jsbn": {
       "version": "0.1.1",
@@ -1274,6 +1306,7 @@
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
       "integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
+      "dev": true,
       "requires": {
         "once": "1.4.0"
       }
@@ -1314,7 +1347,8 @@
     "escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "dev": true
     },
     "escodegen": {
       "version": "1.10.0",
@@ -1487,6 +1521,7 @@
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/ext-list/-/ext-list-2.2.2.tgz",
       "integrity": "sha512-u+SQgsubraE6zItfVA0tBuCBhfU9ogSRnsvygI7wht9TS510oLkBRXBsqopeUG/GBOIQyKZO9wjTqIu/sf5zFA==",
+      "dev": true,
       "requires": {
         "mime-db": "1.34.0"
       }
@@ -1495,6 +1530,7 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/ext-name/-/ext-name-5.0.0.tgz",
       "integrity": "sha512-yblEwXAbGv1VQDmow7s38W77hzAgJAO50ztBLMcUyUBfxv1HC+LGwtiEN+Co6LtlqT/5uwVOxsD4TNIilWhwdQ==",
+      "dev": true,
       "requires": {
         "ext-list": "2.2.2",
         "sort-keys-length": "1.0.1"
@@ -1635,6 +1671,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
       "integrity": "sha1-JcfInLH5B3+IkbvmHY85Dq4lbx4=",
+      "dev": true,
       "requires": {
         "pend": "1.2.0"
       }
@@ -1642,7 +1679,8 @@
     "file-type": {
       "version": "7.7.1",
       "resolved": "https://registry.npmjs.org/file-type/-/file-type-7.7.1.tgz",
-      "integrity": "sha512-bTrKkzzZI6wH+NXhyD3SOXtb2zXTw2SbwI2RxUlRcXVsnN7jNL5hJzVQLYv7FOQhxFkK4XWdAflEaWFpaLLWpQ=="
+      "integrity": "sha512-bTrKkzzZI6wH+NXhyD3SOXtb2zXTw2SbwI2RxUlRcXVsnN7jNL5hJzVQLYv7FOQhxFkK4XWdAflEaWFpaLLWpQ==",
+      "dev": true
     },
     "filename-regex": {
       "version": "2.0.1",
@@ -1653,12 +1691,14 @@
     "filename-reserved-regex": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/filename-reserved-regex/-/filename-reserved-regex-2.0.0.tgz",
-      "integrity": "sha1-q/c9+rc10EVECr/qLZHzieu/oik="
+      "integrity": "sha1-q/c9+rc10EVECr/qLZHzieu/oik=",
+      "dev": true
     },
     "filenamify": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/filenamify/-/filenamify-2.1.0.tgz",
       "integrity": "sha512-ICw7NTT6RsDp2rnYKVd8Fu4cr6ITzGy3+u4vUujPkabyaz+03F24NWEX7fs5fp+kBonlaqPH8fAO2NM+SXt/JA==",
+      "dev": true,
       "requires": {
         "filename-reserved-regex": "2.0.0",
         "strip-outer": "1.0.1",
@@ -1758,6 +1798,7 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/from2/-/from2-2.3.0.tgz",
       "integrity": "sha1-i/tVAr3kpNNs/e6gB/zKIdfjgq8=",
+      "dev": true,
       "requires": {
         "inherits": "2.0.3",
         "readable-stream": "2.3.6"
@@ -1766,7 +1807,8 @@
     "fs-constants": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
-      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow=="
+      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
+      "dev": true
     },
     "fs.realpath": {
       "version": "1.0.0",
@@ -1790,6 +1832,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/get-proxy/-/get-proxy-2.1.0.tgz",
       "integrity": "sha512-zmZIaQTWnNQb4R4fJUEp/FC51eZsc6EkErspy3xtIYStaq8EB/hDIWipxsal+E8rz0qD7f2sL/NA9Xee4RInJw==",
+      "dev": true,
       "requires": {
         "npm-conf": "1.1.3"
       }
@@ -1797,7 +1840,8 @@
     "get-stream": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
-      "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ="
+      "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
+      "dev": true
     },
     "get-value": {
       "version": "2.0.6",
@@ -1857,6 +1901,7 @@
       "version": "8.3.1",
       "resolved": "https://registry.npmjs.org/got/-/got-8.3.1.tgz",
       "integrity": "sha512-tiLX+bnYm5A56T5N/n9Xo89vMaO1mrS9qoDqj3u/anVooqGozvY/HbXzEpDfbNeKsHCBpK40gSbz8wGYSp3i1w==",
+      "dev": true,
       "requires": {
         "@sindresorhus/is": "0.7.0",
         "cacheable-request": "2.1.4",
@@ -1880,12 +1925,14 @@
     "graceful-fs": {
       "version": "4.1.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-      "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg="
+      "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
+      "dev": true
     },
     "graceful-readlink": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
-      "integrity": "sha1-TK+tdrxi8C+gObL5Tpo906ORpyU="
+      "integrity": "sha1-TK+tdrxi8C+gObL5Tpo906ORpyU=",
+      "dev": true
     },
     "growly": {
       "version": "1.3.0",
@@ -1965,12 +2012,14 @@
     "has-symbol-support-x": {
       "version": "1.4.2",
       "resolved": "https://registry.npmjs.org/has-symbol-support-x/-/has-symbol-support-x-1.4.2.tgz",
-      "integrity": "sha512-3ToOva++HaW+eCpgqZrCfN51IPB+7bJNVT6CUATzueB5Heb8o6Nam0V3HG5dlDvZU1Gn5QLcbahiKw/XVk5JJw=="
+      "integrity": "sha512-3ToOva++HaW+eCpgqZrCfN51IPB+7bJNVT6CUATzueB5Heb8o6Nam0V3HG5dlDvZU1Gn5QLcbahiKw/XVk5JJw==",
+      "dev": true
     },
     "has-to-string-tag-x": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/has-to-string-tag-x/-/has-to-string-tag-x-1.4.1.tgz",
       "integrity": "sha512-vdbKfmw+3LoOYVr+mtxHaX5a96+0f3DljYd8JOqvOLsf5mw2Otda2qCDT9qRqLAhrjyQ0h7ual5nOiASpsGNFw==",
+      "dev": true,
       "requires": {
         "has-symbol-support-x": "1.4.2"
       }
@@ -2035,7 +2084,8 @@
     "http-cache-semantics": {
       "version": "3.8.1",
       "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-3.8.1.tgz",
-      "integrity": "sha512-5ai2iksyV8ZXmnZhHH4rWPoxxistEexSi5936zIQ1bnNTW5VnA85B6P/VpXiRM017IgRvb2kKo1a//y+0wSp3w=="
+      "integrity": "sha512-5ai2iksyV8ZXmnZhHH4rWPoxxistEexSi5936zIQ1bnNTW5VnA85B6P/VpXiRM017IgRvb2kKo1a//y+0wSp3w==",
+      "dev": true
     },
     "http-signature": {
       "version": "1.2.0",
@@ -2057,7 +2107,8 @@
     "ieee754": {
       "version": "1.1.12",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.12.tgz",
-      "integrity": "sha512-GguP+DRY+pJ3soyIiGPTvdiVXjZ+DbXOxGpXn3eMvNW4x4irjqXm4wHKscC+TfxSJ0yw/S1F24tqdMNsMZTiLA=="
+      "integrity": "sha512-GguP+DRY+pJ3soyIiGPTvdiVXjZ+DbXOxGpXn3eMvNW4x4irjqXm4wHKscC+TfxSJ0yw/S1F24tqdMNsMZTiLA==",
+      "dev": true
     },
     "import-local": {
       "version": "1.0.0",
@@ -2088,17 +2139,20 @@
     "inherits": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+      "dev": true
     },
     "ini": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
-      "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw=="
+      "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
+      "dev": true
     },
     "into-stream": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/into-stream/-/into-stream-3.1.0.tgz",
       "integrity": "sha1-lvsKk2wSur1v8XUqF9BWFqvQlMY=",
+      "dev": true,
       "requires": {
         "from2": "2.3.0",
         "p-is-promise": "1.1.0"
@@ -2258,7 +2312,8 @@
     "is-natural-number": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/is-natural-number/-/is-natural-number-4.0.1.tgz",
-      "integrity": "sha1-q5124dtM7VHjXeDHLr7PCfc0zeg="
+      "integrity": "sha1-q5124dtM7VHjXeDHLr7PCfc0zeg=",
+      "dev": true
     },
     "is-number": {
       "version": "3.0.0",
@@ -2272,7 +2327,8 @@
     "is-object": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-object/-/is-object-1.0.1.tgz",
-      "integrity": "sha1-iVJojF7C/9awPsyF52ngKQMINHA="
+      "integrity": "sha1-iVJojF7C/9awPsyF52ngKQMINHA=",
+      "dev": true
     },
     "is-odd": {
       "version": "2.0.0",
@@ -2294,7 +2350,8 @@
     "is-plain-obj": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
-      "integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4="
+      "integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4=",
+      "dev": true
     },
     "is-plain-object": {
       "version": "2.0.4",
@@ -2329,12 +2386,14 @@
     "is-retry-allowed": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-1.1.0.tgz",
-      "integrity": "sha1-EaBgVotnM5REAz0BJaYaINVk+zQ="
+      "integrity": "sha1-EaBgVotnM5REAz0BJaYaINVk+zQ=",
+      "dev": true
     },
     "is-stream": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
+      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
+      "dev": true
     },
     "is-symbol": {
       "version": "1.0.1",
@@ -2363,7 +2422,8 @@
     "isarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+      "dev": true
     },
     "isexe": {
       "version": "2.0.0",
@@ -2499,6 +2559,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isurl/-/isurl-1.0.0.tgz",
       "integrity": "sha512-1P/yWsxPlDtn7QeRD+ULKQPaIaN6yF368GZ2vDfv0AL0NwpStafjWCDDdn0k8wgFMWpVAqG7oJhxHnlud42i9w==",
+      "dev": true,
       "requires": {
         "has-to-string-tag-x": "1.4.1",
         "is-object": "1.0.1"
@@ -2957,7 +3018,8 @@
     "json-buffer": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.0.tgz",
-      "integrity": "sha1-Wx85evx11ne96Lz8Dkfh+aPZqJg="
+      "integrity": "sha1-Wx85evx11ne96Lz8Dkfh+aPZqJg=",
+      "dev": true
     },
     "json-schema": {
       "version": "0.2.3",
@@ -2999,6 +3061,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-3.0.0.tgz",
       "integrity": "sha512-eguHnq22OE3uVoSYG0LVWNP+4ppamWr9+zWBe1bsNcovIMy6huUJFPgy4mGwCd/rnl3vOLGW1MTlu4c57CT1xA==",
+      "dev": true,
       "requires": {
         "json-buffer": "3.0.0"
       }
@@ -3120,7 +3183,8 @@
     "lowercase-keys": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.1.tgz",
-      "integrity": "sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA=="
+      "integrity": "sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA==",
+      "dev": true
     },
     "lru-cache": {
       "version": "4.1.3",
@@ -3136,6 +3200,7 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.3.0.tgz",
       "integrity": "sha512-2w31R7SJtieJJnQtGc7RVL2StM2vGYVfqUOvUDxH6bC6aJTxPxTF0GnIgCyu7tjockiUWAYQRbxa7vKn34s5sQ==",
+      "dev": true,
       "requires": {
         "pify": "3.0.0"
       }
@@ -3264,7 +3329,8 @@
     "mime-db": {
       "version": "1.34.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.34.0.tgz",
-      "integrity": "sha1-RS0Oz/XDA0am3B5kseruDTcZ/5o="
+      "integrity": "sha1-RS0Oz/XDA0am3B5kseruDTcZ/5o=",
+      "dev": true
     },
     "mime-types": {
       "version": "2.1.18",
@@ -3292,7 +3358,8 @@
     "mimic-response": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.0.tgz",
-      "integrity": "sha1-3z02Uqc/3ta5sLJBRub9BSNTRY4="
+      "integrity": "sha1-3z02Uqc/3ta5sLJBRub9BSNTRY4=",
+      "dev": true
     },
     "minimatch": {
       "version": "3.0.4",
@@ -3306,7 +3373,8 @@
     "minimist": {
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+      "dev": true
     },
     "mixin-deep": {
       "version": "1.3.1",
@@ -3333,6 +3401,7 @@
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+      "dev": true,
       "requires": {
         "minimist": "0.0.8"
       }
@@ -3420,6 +3489,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-2.0.1.tgz",
       "integrity": "sha512-D6MUW4K/VzoJ4rJ01JFKxDrtY1v9wrgzCX5f2qj/lzH1m/lW6MhUZFKerVsnyjOhOsYzI9Kqqak+10l4LvLpMw==",
+      "dev": true,
       "requires": {
         "prepend-http": "2.0.0",
         "query-string": "5.1.1",
@@ -3430,6 +3500,7 @@
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/sort-keys/-/sort-keys-2.0.0.tgz",
           "integrity": "sha1-ZYU1WEhh7JfXMNbPQYIuH1ZoQSg=",
+          "dev": true,
           "requires": {
             "is-plain-obj": "1.1.0"
           }
@@ -3440,6 +3511,7 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/npm-conf/-/npm-conf-1.1.3.tgz",
       "integrity": "sha512-Yic4bZHJOt9RCFbRP3GgpqhScOY4HH3V2P8yBj6CeYq118Qr+BLXqT2JvpJ00mryLESpgOxf5XlFv4ZjXxLScw==",
+      "dev": true,
       "requires": {
         "config-chain": "1.1.11",
         "pify": "3.0.0"
@@ -3475,7 +3547,8 @@
     "object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+      "dev": true
     },
     "object-copy": {
       "version": "0.1.0",
@@ -3547,6 +3620,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "dev": true,
       "requires": {
         "wrappy": "1.0.2"
       }
@@ -3609,12 +3683,14 @@
     "p-cancelable": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-0.4.1.tgz",
-      "integrity": "sha512-HNa1A8LvB1kie7cERyy21VNeHb2CWJJYqyyC2o3klWFfMGlFmWv2Z7sFgZH8ZiaYL95ydToKTFVXgMV/Os0bBQ=="
+      "integrity": "sha512-HNa1A8LvB1kie7cERyy21VNeHb2CWJJYqyyC2o3klWFfMGlFmWv2Z7sFgZH8ZiaYL95ydToKTFVXgMV/Os0bBQ==",
+      "dev": true
     },
     "p-event": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/p-event/-/p-event-1.3.0.tgz",
       "integrity": "sha1-jmtPT2XHK8W2/ii3XtqHT5akoIU=",
+      "dev": true,
       "requires": {
         "p-timeout": "1.2.1"
       },
@@ -3623,6 +3699,7 @@
           "version": "1.2.1",
           "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-1.2.1.tgz",
           "integrity": "sha1-XrOzU7f86Z8QGhA4iAuwVOu+o4Y=",
+          "dev": true,
           "requires": {
             "p-finally": "1.0.0"
           }
@@ -3632,12 +3709,14 @@
     "p-finally": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
-      "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4="
+      "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
+      "dev": true
     },
     "p-is-promise": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/p-is-promise/-/p-is-promise-1.1.0.tgz",
-      "integrity": "sha1-nJRWmJ6fZYgBewQ01WCXZ1w9oF4="
+      "integrity": "sha1-nJRWmJ6fZYgBewQ01WCXZ1w9oF4=",
+      "dev": true
     },
     "p-limit": {
       "version": "1.3.0",
@@ -3661,6 +3740,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-2.0.1.tgz",
       "integrity": "sha512-88em58dDVB/KzPEx1X0N3LwFfYZPyDc4B6eF38M1rk9VTZMbxXXgjugz8mmwpS9Ox4BDZ+t6t3QP5+/gazweIA==",
+      "dev": true,
       "requires": {
         "p-finally": "1.0.0"
       }
@@ -3750,7 +3830,8 @@
     "pend": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
-      "integrity": "sha1-elfrVQpng/kRUzH89GY9XI4AelA="
+      "integrity": "sha1-elfrVQpng/kRUzH89GY9XI4AelA=",
+      "dev": true
     },
     "performance-now": {
       "version": "2.1.0",
@@ -3761,17 +3842,20 @@
     "pify": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
-      "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
+      "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+      "dev": true
     },
     "pinkie": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
-      "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA="
+      "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
+      "dev": true
     },
     "pinkie-promise": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
       "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
+      "dev": true,
       "requires": {
         "pinkie": "2.0.4"
       }
@@ -3806,7 +3890,8 @@
     "prepend-http": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-2.0.0.tgz",
-      "integrity": "sha1-6SQ0v6XqjBn0HN/UAddBo8gZ2Jc="
+      "integrity": "sha1-6SQ0v6XqjBn0HN/UAddBo8gZ2Jc=",
+      "dev": true
     },
     "preserve": {
       "version": "0.2.0",
@@ -3841,12 +3926,14 @@
     "process-nextick-args": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
-      "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw=="
+      "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
+      "dev": true
     },
     "proto-list": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
-      "integrity": "sha1-IS1b/hMYMGpCD2QCuOJv85ZHqEk="
+      "integrity": "sha1-IS1b/hMYMGpCD2QCuOJv85ZHqEk=",
+      "dev": true
     },
     "pseudomap": {
       "version": "1.0.2",
@@ -3876,6 +3963,7 @@
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/query-string/-/query-string-5.1.1.tgz",
       "integrity": "sha512-gjWOsm2SoGlgLEdAGt7a6slVOk9mGiXmPFMqrEhLQ68rhQuBnpfs3+EmlvqKyxnCo9/PPlF+9MtY02S1aFg+Jw==",
+      "dev": true,
       "requires": {
         "decode-uri-component": "0.2.0",
         "object-assign": "4.1.1",
@@ -3953,6 +4041,7 @@
       "version": "2.3.6",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
       "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+      "dev": true,
       "requires": {
         "core-util-is": "1.0.2",
         "inherits": "2.0.3",
@@ -4132,6 +4221,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/responselike/-/responselike-1.0.2.tgz",
       "integrity": "sha1-kYcg7ztjHFZCvgaPFa3lpG9Loec=",
+      "dev": true,
       "requires": {
         "lowercase-keys": "1.0.1"
       }
@@ -4170,7 +4260,8 @@
     "safe-buffer": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true
     },
     "safe-regex": {
       "version": "1.1.0",
@@ -4248,6 +4339,7 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/seek-bzip/-/seek-bzip-1.0.5.tgz",
       "integrity": "sha1-z+kXyz0nS8/6x5J1ivUxc+sfq9w=",
+      "dev": true,
       "requires": {
         "commander": "2.8.1"
       }
@@ -4426,6 +4518,7 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/sort-keys/-/sort-keys-1.1.2.tgz",
       "integrity": "sha1-RBttTTRnmPG05J6JIK37oOVD+a0=",
+      "dev": true,
       "requires": {
         "is-plain-obj": "1.1.0"
       }
@@ -4434,6 +4527,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/sort-keys-length/-/sort-keys-length-1.0.1.tgz",
       "integrity": "sha1-nLb09OnkgVWmqgZx7dM2/xR5oYg=",
+      "dev": true,
       "requires": {
         "sort-keys": "1.1.2"
       }
@@ -4572,7 +4666,8 @@
     "strict-uri-encode": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz",
-      "integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM="
+      "integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM=",
+      "dev": true
     },
     "string-length": {
       "version": "2.0.0",
@@ -4598,6 +4693,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
       "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dev": true,
       "requires": {
         "safe-buffer": "5.1.2"
       }
@@ -4629,6 +4725,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/strip-dirs/-/strip-dirs-2.1.0.tgz",
       "integrity": "sha512-JOCxOeKLm2CAS73y/U4ZeZPTkE+gNVCzKt7Eox84Iej1LT/2pTWYpZKJuxwQpvX1LiZb1xokNR7RLfuBAa7T3g==",
+      "dev": true,
       "requires": {
         "is-natural-number": "4.0.1"
       }
@@ -4643,6 +4740,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/strip-outer/-/strip-outer-1.0.1.tgz",
       "integrity": "sha512-k55yxKHwaXnpYGsOzg4Vl8+tDrWylxDEpknGjhTiZB8dFRU5rTo9CAzeycivxV3s+zlTKwrs6WxMxR95n26kwg==",
+      "dev": true,
       "requires": {
         "escape-string-regexp": "1.0.5"
       }
@@ -4666,6 +4764,7 @@
       "version": "1.6.1",
       "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.6.1.tgz",
       "integrity": "sha512-IFLM5wp3QrJODQFPm6/to3LJZrONdBY/otxcvDIQzu217zKye6yVR3hhi9lAjrC2Z+m/j5oDxMPb1qcd8cIvpA==",
+      "dev": true,
       "requires": {
         "bl": "1.2.2",
         "buffer-alloc": "1.2.0",
@@ -4727,12 +4826,14 @@
     "through": {
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
-      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
+      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
+      "dev": true
     },
     "timed-out": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/timed-out/-/timed-out-4.0.1.tgz",
-      "integrity": "sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8="
+      "integrity": "sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8=",
+      "dev": true
     },
     "tmpl": {
       "version": "1.0.4",
@@ -4743,7 +4844,8 @@
     "to-buffer": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/to-buffer/-/to-buffer-1.1.1.tgz",
-      "integrity": "sha512-lx9B5iv7msuFYE3dytT+KE5tap+rNYw+K4jVkb9R/asAb+pbBSM17jtunHplhBe6RRJdZx3Pn2Jph24O32mOVg=="
+      "integrity": "sha512-lx9B5iv7msuFYE3dytT+KE5tap+rNYw+K4jVkb9R/asAb+pbBSM17jtunHplhBe6RRJdZx3Pn2Jph24O32mOVg==",
+      "dev": true
     },
     "to-fast-properties": {
       "version": "1.0.3",
@@ -4813,6 +4915,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/trim-repeated/-/trim-repeated-1.0.0.tgz",
       "integrity": "sha1-42RqLqTokTEr9+rObPsFOAvAHCE=",
+      "dev": true,
       "requires": {
         "escape-string-regexp": "1.0.5"
       }
@@ -4827,6 +4930,7 @@
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
       "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+      "dev": true,
       "requires": {
         "safe-buffer": "5.1.2"
       }
@@ -4885,6 +4989,7 @@
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/unbzip2-stream/-/unbzip2-stream-1.2.5.tgz",
       "integrity": "sha512-izD3jxT8xkzwtXRUZjtmRwKnZoeECrfZ8ra/ketwOcusbZEp4mjULMnJOCfTDZBgGQAAY1AJ/IgxcwkavcX9Og==",
+      "dev": true,
       "requires": {
         "buffer": "3.6.0",
         "through": "2.3.8"
@@ -4975,6 +5080,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-3.0.0.tgz",
       "integrity": "sha1-FrXK/Afb42dsGxmZF3gj1lA6yww=",
+      "dev": true,
       "requires": {
         "prepend-http": "2.0.0"
       }
@@ -4982,7 +5088,8 @@
     "url-to-options": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/url-to-options/-/url-to-options-1.0.1.tgz",
-      "integrity": "sha1-FQWgOiiaSMvXpDTvuu7FBV9WM6k="
+      "integrity": "sha1-FQWgOiiaSMvXpDTvuu7FBV9WM6k=",
+      "dev": true
     },
     "use": {
       "version": "3.1.0",
@@ -5004,7 +5111,8 @@
     "util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+      "dev": true
     },
     "util.promisify": {
       "version": "1.0.0",
@@ -5183,7 +5291,8 @@
     "wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "dev": true
     },
     "write-file-atomic": {
       "version": "2.3.0",
@@ -5215,7 +5324,8 @@
     "xtend": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
-      "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
+      "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
+      "dev": true
     },
     "y18n": {
       "version": "3.2.1",
@@ -5283,6 +5393,7 @@
       "version": "2.9.2",
       "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.9.2.tgz",
       "integrity": "sha1-T7G8euH8L1cDe1SvasyP4QMcW3c=",
+      "dev": true,
       "requires": {
         "buffer-crc32": "0.2.13",
         "fd-slicer": "1.1.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
-  "name": "esy-bash",
-  "version": "0.1.24",
+  "name": "esy-bash-test",
+  "version": "0.0.100",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -19,9 +19,9 @@
       "integrity": "sha1-6IRK4loVlcz9QriWI7Q3bKBtIl0=",
       "dev": true,
       "requires": {
-        "chalk": "2.4.1",
-        "esutils": "2.0.2",
-        "js-tokens": "3.0.2"
+        "chalk": "^2.0.0",
+        "esutils": "^2.0.2",
+        "js-tokens": "^3.0.0"
       }
     },
     "@sindresorhus/is": {
@@ -48,7 +48,7 @@
       "integrity": "sha512-KjZwU26uG3u6eZcfGbTULzFcsoz6pegNKtHPksZPOUsiKo5bUmiBPa38FuHZ/Eun+XYh/JCCkS9AS3Lu4McQOQ==",
       "dev": true,
       "requires": {
-        "acorn": "5.7.1"
+        "acorn": "^5.0.0"
       }
     },
     "ajv": {
@@ -57,10 +57,10 @@
       "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
       "dev": true,
       "requires": {
-        "co": "4.6.0",
-        "fast-deep-equal": "1.1.0",
-        "fast-json-stable-stringify": "2.0.0",
-        "json-schema-traverse": "0.3.1"
+        "co": "^4.6.0",
+        "fast-deep-equal": "^1.0.0",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.3.0"
       }
     },
     "align-text": {
@@ -69,9 +69,9 @@
       "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
       "dev": true,
       "requires": {
-        "kind-of": "3.2.2",
-        "longest": "1.0.1",
-        "repeat-string": "1.6.1"
+        "kind-of": "^3.0.2",
+        "longest": "^1.0.1",
+        "repeat-string": "^1.5.2"
       }
     },
     "amdefine": {
@@ -98,7 +98,7 @@
       "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
       "dev": true,
       "requires": {
-        "color-convert": "1.9.2"
+        "color-convert": "^1.9.0"
       }
     },
     "anymatch": {
@@ -107,8 +107,8 @@
       "integrity": "sha512-5teOsQWABXHHBFP9y3skS5P3d/WfWXpv3FUpy+LorMrNYaT9pI4oLMQX7jzQ2KklNpGpWHzdCXTDT2Y3XGlZBw==",
       "dev": true,
       "requires": {
-        "micromatch": "3.1.10",
-        "normalize-path": "2.1.1"
+        "micromatch": "^3.1.4",
+        "normalize-path": "^2.1.1"
       },
       "dependencies": {
         "kind-of": {
@@ -123,19 +123,19 @@
           "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
           "dev": true,
           "requires": {
-            "arr-diff": "4.0.0",
-            "array-unique": "0.3.2",
-            "braces": "2.3.2",
-            "define-property": "2.0.2",
-            "extend-shallow": "3.0.2",
-            "extglob": "2.0.4",
-            "fragment-cache": "0.2.1",
-            "kind-of": "6.0.2",
-            "nanomatch": "1.2.9",
-            "object.pick": "1.3.0",
-            "regex-not": "1.0.2",
-            "snapdragon": "0.8.2",
-            "to-regex": "3.0.2"
+            "arr-diff": "^4.0.0",
+            "array-unique": "^0.3.2",
+            "braces": "^2.3.1",
+            "define-property": "^2.0.2",
+            "extend-shallow": "^3.0.2",
+            "extglob": "^2.0.4",
+            "fragment-cache": "^0.2.1",
+            "kind-of": "^6.0.2",
+            "nanomatch": "^1.2.9",
+            "object.pick": "^1.3.0",
+            "regex-not": "^1.0.0",
+            "snapdragon": "^0.8.1",
+            "to-regex": "^3.0.2"
           }
         }
       }
@@ -146,7 +146,7 @@
       "integrity": "sha512-P009oYkeHyU742iSZJzZZywj4QRJdnTWffaKuJQLablCZ1uz6/cW4yaRgcDaoQ+uwOxxnt0gRUcwfsNP2ri0gw==",
       "dev": true,
       "requires": {
-        "default-require-extensions": "2.0.0"
+        "default-require-extensions": "^2.0.0"
       }
     },
     "argparse": {
@@ -155,7 +155,7 @@
       "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
       "dev": true,
       "requires": {
-        "sprintf-js": "1.0.3"
+        "sprintf-js": "~1.0.2"
       }
     },
     "arr-diff": {
@@ -224,7 +224,7 @@
       "integrity": "sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==",
       "dev": true,
       "requires": {
-        "lodash": "4.17.10"
+        "lodash": "^4.17.10"
       }
     },
     "async-limiter": {
@@ -263,9 +263,9 @@
       "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
       "dev": true,
       "requires": {
-        "chalk": "1.1.3",
-        "esutils": "2.0.2",
-        "js-tokens": "3.0.2"
+        "chalk": "^1.1.3",
+        "esutils": "^2.0.2",
+        "js-tokens": "^3.0.2"
       },
       "dependencies": {
         "ansi-styles": {
@@ -280,11 +280,11 @@
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
+            "ansi-styles": "^2.2.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
           }
         },
         "strip-ansi": {
@@ -293,7 +293,7 @@
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
           "requires": {
-            "ansi-regex": "2.1.1"
+            "ansi-regex": "^2.0.0"
           }
         },
         "supports-color": {
@@ -310,25 +310,25 @@
       "integrity": "sha512-6jyFLuDmeidKmUEb3NM+/yawG0M2bDZ9Z1qbZP59cyHLz8kYGKYwpJP0UwUKKUiTRNvxfLesJnTedqczP7cTDA==",
       "dev": true,
       "requires": {
-        "babel-code-frame": "6.26.0",
-        "babel-generator": "6.26.1",
-        "babel-helpers": "6.24.1",
-        "babel-messages": "6.23.0",
-        "babel-register": "6.26.0",
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0",
-        "babylon": "6.18.0",
-        "convert-source-map": "1.5.1",
-        "debug": "2.6.9",
-        "json5": "0.5.1",
-        "lodash": "4.17.10",
-        "minimatch": "3.0.4",
-        "path-is-absolute": "1.0.1",
-        "private": "0.1.8",
-        "slash": "1.0.0",
-        "source-map": "0.5.7"
+        "babel-code-frame": "^6.26.0",
+        "babel-generator": "^6.26.0",
+        "babel-helpers": "^6.24.1",
+        "babel-messages": "^6.23.0",
+        "babel-register": "^6.26.0",
+        "babel-runtime": "^6.26.0",
+        "babel-template": "^6.26.0",
+        "babel-traverse": "^6.26.0",
+        "babel-types": "^6.26.0",
+        "babylon": "^6.18.0",
+        "convert-source-map": "^1.5.1",
+        "debug": "^2.6.9",
+        "json5": "^0.5.1",
+        "lodash": "^4.17.4",
+        "minimatch": "^3.0.4",
+        "path-is-absolute": "^1.0.1",
+        "private": "^0.1.8",
+        "slash": "^1.0.0",
+        "source-map": "^0.5.7"
       }
     },
     "babel-generator": {
@@ -337,14 +337,14 @@
       "integrity": "sha512-HyfwY6ApZj7BYTcJURpM5tznulaBvyio7/0d4zFOeMPUmfxkCjHocCuoLa2SAGzBI8AREcH3eP3758F672DppA==",
       "dev": true,
       "requires": {
-        "babel-messages": "6.23.0",
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0",
-        "detect-indent": "4.0.0",
-        "jsesc": "1.3.0",
-        "lodash": "4.17.10",
-        "source-map": "0.5.7",
-        "trim-right": "1.0.1"
+        "babel-messages": "^6.23.0",
+        "babel-runtime": "^6.26.0",
+        "babel-types": "^6.26.0",
+        "detect-indent": "^4.0.0",
+        "jsesc": "^1.3.0",
+        "lodash": "^4.17.4",
+        "source-map": "^0.5.7",
+        "trim-right": "^1.0.1"
       }
     },
     "babel-helpers": {
@@ -353,8 +353,8 @@
       "integrity": "sha1-NHHenK7DiOXIUOWX5Yom3fN2ArI=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0"
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1"
       }
     },
     "babel-jest": {
@@ -363,8 +363,8 @@
       "integrity": "sha1-u6079SP7IC2gXtCmVAtIyE7tE6Y=",
       "dev": true,
       "requires": {
-        "babel-plugin-istanbul": "4.1.6",
-        "babel-preset-jest": "23.0.1"
+        "babel-plugin-istanbul": "^4.1.6",
+        "babel-preset-jest": "^23.0.1"
       }
     },
     "babel-messages": {
@@ -373,7 +373,7 @@
       "integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0"
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-istanbul": {
@@ -382,10 +382,10 @@
       "integrity": "sha512-PWP9FQ1AhZhS01T/4qLSKoHGY/xvkZdVBGlKM/HuxxS3+sC66HhTNR7+MpbO/so/cz/wY94MeSWJuP1hXIPfwQ==",
       "dev": true,
       "requires": {
-        "babel-plugin-syntax-object-rest-spread": "6.13.0",
-        "find-up": "2.1.0",
-        "istanbul-lib-instrument": "1.10.1",
-        "test-exclude": "4.2.1"
+        "babel-plugin-syntax-object-rest-spread": "^6.13.0",
+        "find-up": "^2.1.0",
+        "istanbul-lib-instrument": "^1.10.1",
+        "test-exclude": "^4.2.1"
       }
     },
     "babel-plugin-jest-hoist": {
@@ -406,8 +406,8 @@
       "integrity": "sha1-YxzFRcbPAhlDATvK8i9F2H/mIZg=",
       "dev": true,
       "requires": {
-        "babel-plugin-jest-hoist": "23.0.1",
-        "babel-plugin-syntax-object-rest-spread": "6.13.0"
+        "babel-plugin-jest-hoist": "^23.0.1",
+        "babel-plugin-syntax-object-rest-spread": "^6.13.0"
       }
     },
     "babel-register": {
@@ -416,13 +416,13 @@
       "integrity": "sha1-btAhFz4vy0htestFxgCahW9kcHE=",
       "dev": true,
       "requires": {
-        "babel-core": "6.26.3",
-        "babel-runtime": "6.26.0",
-        "core-js": "2.5.7",
-        "home-or-tmp": "2.0.0",
-        "lodash": "4.17.10",
-        "mkdirp": "0.5.1",
-        "source-map-support": "0.4.18"
+        "babel-core": "^6.26.0",
+        "babel-runtime": "^6.26.0",
+        "core-js": "^2.5.0",
+        "home-or-tmp": "^2.0.0",
+        "lodash": "^4.17.4",
+        "mkdirp": "^0.5.1",
+        "source-map-support": "^0.4.15"
       }
     },
     "babel-runtime": {
@@ -431,8 +431,8 @@
       "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
       "dev": true,
       "requires": {
-        "core-js": "2.5.7",
-        "regenerator-runtime": "0.11.1"
+        "core-js": "^2.4.0",
+        "regenerator-runtime": "^0.11.0"
       }
     },
     "babel-template": {
@@ -441,11 +441,11 @@
       "integrity": "sha1-3gPi0WOWsGn0bdn/+FIfsaDjXgI=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0",
-        "babylon": "6.18.0",
-        "lodash": "4.17.10"
+        "babel-runtime": "^6.26.0",
+        "babel-traverse": "^6.26.0",
+        "babel-types": "^6.26.0",
+        "babylon": "^6.18.0",
+        "lodash": "^4.17.4"
       }
     },
     "babel-traverse": {
@@ -454,15 +454,15 @@
       "integrity": "sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=",
       "dev": true,
       "requires": {
-        "babel-code-frame": "6.26.0",
-        "babel-messages": "6.23.0",
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0",
-        "babylon": "6.18.0",
-        "debug": "2.6.9",
-        "globals": "9.18.0",
-        "invariant": "2.2.4",
-        "lodash": "4.17.10"
+        "babel-code-frame": "^6.26.0",
+        "babel-messages": "^6.23.0",
+        "babel-runtime": "^6.26.0",
+        "babel-types": "^6.26.0",
+        "babylon": "^6.18.0",
+        "debug": "^2.6.8",
+        "globals": "^9.18.0",
+        "invariant": "^2.2.2",
+        "lodash": "^4.17.4"
       }
     },
     "babel-types": {
@@ -471,10 +471,10 @@
       "integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0",
-        "esutils": "2.0.2",
-        "lodash": "4.17.10",
-        "to-fast-properties": "1.0.3"
+        "babel-runtime": "^6.26.0",
+        "esutils": "^2.0.2",
+        "lodash": "^4.17.4",
+        "to-fast-properties": "^1.0.3"
       }
     },
     "babylon": {
@@ -495,13 +495,13 @@
       "integrity": "sha512-5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==",
       "dev": true,
       "requires": {
-        "cache-base": "1.0.1",
-        "class-utils": "0.3.6",
-        "component-emitter": "1.2.1",
-        "define-property": "1.0.0",
-        "isobject": "3.0.1",
-        "mixin-deep": "1.3.1",
-        "pascalcase": "0.1.1"
+        "cache-base": "^1.0.1",
+        "class-utils": "^0.3.5",
+        "component-emitter": "^1.2.1",
+        "define-property": "^1.0.0",
+        "isobject": "^3.0.1",
+        "mixin-deep": "^1.2.0",
+        "pascalcase": "^0.1.1"
       },
       "dependencies": {
         "define-property": {
@@ -510,7 +510,7 @@
           "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
           "dev": true,
           "requires": {
-            "is-descriptor": "1.0.2"
+            "is-descriptor": "^1.0.0"
           }
         },
         "is-accessor-descriptor": {
@@ -519,7 +519,7 @@
           "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
           "dev": true,
           "requires": {
-            "kind-of": "6.0.2"
+            "kind-of": "^6.0.0"
           }
         },
         "is-data-descriptor": {
@@ -528,7 +528,7 @@
           "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
           "dev": true,
           "requires": {
-            "kind-of": "6.0.2"
+            "kind-of": "^6.0.0"
           }
         },
         "is-descriptor": {
@@ -537,9 +537,9 @@
           "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
           "dev": true,
           "requires": {
-            "is-accessor-descriptor": "1.0.0",
-            "is-data-descriptor": "1.0.0",
-            "kind-of": "6.0.2"
+            "is-accessor-descriptor": "^1.0.0",
+            "is-data-descriptor": "^1.0.0",
+            "kind-of": "^6.0.2"
           }
         },
         "kind-of": {
@@ -563,7 +563,7 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "tweetnacl": "0.14.5"
+        "tweetnacl": "^0.14.3"
       }
     },
     "bl": {
@@ -572,8 +572,8 @@
       "integrity": "sha512-e8tQYnZodmebYDWGH7KMRvtzKXaJHx3BbilrgZCfvyLUYdKpK1t5PSPmpkny/SgiTSCnjfLW7v5rlONXVFkQEA==",
       "dev": true,
       "requires": {
-        "readable-stream": "2.3.6",
-        "safe-buffer": "5.1.2"
+        "readable-stream": "^2.3.5",
+        "safe-buffer": "^5.1.1"
       }
     },
     "brace-expansion": {
@@ -582,7 +582,7 @@
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
       "dev": true,
       "requires": {
-        "balanced-match": "1.0.0",
+        "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
       }
     },
@@ -592,16 +592,16 @@
       "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
       "dev": true,
       "requires": {
-        "arr-flatten": "1.1.0",
-        "array-unique": "0.3.2",
-        "extend-shallow": "2.0.1",
-        "fill-range": "4.0.0",
-        "isobject": "3.0.1",
-        "repeat-element": "1.1.2",
-        "snapdragon": "0.8.2",
-        "snapdragon-node": "2.1.1",
-        "split-string": "3.1.0",
-        "to-regex": "3.0.2"
+        "arr-flatten": "^1.1.0",
+        "array-unique": "^0.3.2",
+        "extend-shallow": "^2.0.1",
+        "fill-range": "^4.0.0",
+        "isobject": "^3.0.1",
+        "repeat-element": "^1.1.2",
+        "snapdragon": "^0.8.1",
+        "snapdragon-node": "^2.0.1",
+        "split-string": "^3.0.2",
+        "to-regex": "^3.0.1"
       },
       "dependencies": {
         "extend-shallow": {
@@ -610,7 +610,7 @@
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "dev": true,
           "requires": {
-            "is-extendable": "0.1.1"
+            "is-extendable": "^0.1.0"
           }
         }
       }
@@ -636,7 +636,7 @@
       "integrity": "sha1-mseNPtXZFYBP2HrLFYvHlxR6Fxk=",
       "dev": true,
       "requires": {
-        "node-int64": "0.4.0"
+        "node-int64": "^0.4.0"
       }
     },
     "buffer": {
@@ -646,8 +646,8 @@
       "dev": true,
       "requires": {
         "base64-js": "0.0.8",
-        "ieee754": "1.1.12",
-        "isarray": "1.0.0"
+        "ieee754": "^1.1.4",
+        "isarray": "^1.0.0"
       }
     },
     "buffer-alloc": {
@@ -656,8 +656,8 @@
       "integrity": "sha512-CFsHQgjtW1UChdXgbyJGtnm+O/uLQeZdtbDo8mfUgYXCHSM1wgrVxXm6bSyrUuErEb+4sYVGCzASBRot7zyrow==",
       "dev": true,
       "requires": {
-        "buffer-alloc-unsafe": "1.1.0",
-        "buffer-fill": "1.0.0"
+        "buffer-alloc-unsafe": "^1.1.0",
+        "buffer-fill": "^1.0.0"
       }
     },
     "buffer-alloc-unsafe": {
@@ -696,15 +696,15 @@
       "integrity": "sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ==",
       "dev": true,
       "requires": {
-        "collection-visit": "1.0.0",
-        "component-emitter": "1.2.1",
-        "get-value": "2.0.6",
-        "has-value": "1.0.0",
-        "isobject": "3.0.1",
-        "set-value": "2.0.0",
-        "to-object-path": "0.3.0",
-        "union-value": "1.0.0",
-        "unset-value": "1.0.0"
+        "collection-visit": "^1.0.0",
+        "component-emitter": "^1.2.1",
+        "get-value": "^2.0.6",
+        "has-value": "^1.0.0",
+        "isobject": "^3.0.1",
+        "set-value": "^2.0.0",
+        "to-object-path": "^0.3.0",
+        "union-value": "^1.0.0",
+        "unset-value": "^1.0.0"
       }
     },
     "cacheable-request": {
@@ -749,7 +749,7 @@
       "integrity": "sha1-HF/MSJ/QqwDU8ax64QcuMXP7q28=",
       "dev": true,
       "requires": {
-        "rsvp": "3.6.2"
+        "rsvp": "^3.3.3"
       }
     },
     "caseless": {
@@ -764,10 +764,10 @@
       "integrity": "sha512-Cg8/ZSBEa8ZVY9HspcGUYaK63d/bN7rqS3CYCzEGUxuYv6UlmcjzDUz2fCFFHyTvUW5Pk0I+3hkA3iXlIj6guA==",
       "dev": true,
       "requires": {
-        "get-proxy": "2.1.0",
-        "isurl": "1.0.0",
-        "tunnel-agent": "0.6.0",
-        "url-to-options": "1.0.1"
+        "get-proxy": "^2.0.0",
+        "isurl": "^1.0.0-alpha5",
+        "tunnel-agent": "^0.6.0",
+        "url-to-options": "^1.0.1"
       }
     },
     "center-align": {
@@ -777,8 +777,8 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "align-text": "0.1.4",
-        "lazy-cache": "1.0.4"
+        "align-text": "^0.1.3",
+        "lazy-cache": "^1.0.3"
       }
     },
     "chalk": {
@@ -787,9 +787,9 @@
       "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
       "dev": true,
       "requires": {
-        "ansi-styles": "3.2.1",
-        "escape-string-regexp": "1.0.5",
-        "supports-color": "5.4.0"
+        "ansi-styles": "^3.2.1",
+        "escape-string-regexp": "^1.0.5",
+        "supports-color": "^5.3.0"
       }
     },
     "ci-info": {
@@ -804,10 +804,10 @@
       "integrity": "sha512-qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg==",
       "dev": true,
       "requires": {
-        "arr-union": "3.1.0",
-        "define-property": "0.2.5",
-        "isobject": "3.0.1",
-        "static-extend": "0.1.2"
+        "arr-union": "^3.1.0",
+        "define-property": "^0.2.5",
+        "isobject": "^3.0.0",
+        "static-extend": "^0.1.1"
       },
       "dependencies": {
         "define-property": {
@@ -816,7 +816,7 @@
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "dev": true,
           "requires": {
-            "is-descriptor": "0.1.6"
+            "is-descriptor": "^0.1.0"
           }
         }
       }
@@ -828,8 +828,8 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "center-align": "0.1.3",
-        "right-align": "0.1.3",
+        "center-align": "^0.1.1",
+        "right-align": "^0.1.1",
         "wordwrap": "0.0.2"
       },
       "dependencies": {
@@ -848,7 +848,7 @@
       "integrity": "sha1-0dyXOSAxTfZ/vrlCI7TuNQI56Ws=",
       "dev": true,
       "requires": {
-        "mimic-response": "1.0.0"
+        "mimic-response": "^1.0.0"
       }
     },
     "co": {
@@ -869,8 +869,8 @@
       "integrity": "sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=",
       "dev": true,
       "requires": {
-        "map-visit": "1.0.0",
-        "object-visit": "1.0.1"
+        "map-visit": "^1.0.0",
+        "object-visit": "^1.0.0"
       }
     },
     "color-convert": {
@@ -894,7 +894,7 @@
       "integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
       "dev": true,
       "requires": {
-        "delayed-stream": "1.0.0"
+        "delayed-stream": "~1.0.0"
       }
     },
     "commander": {
@@ -903,7 +903,7 @@
       "integrity": "sha1-Br42f+v9oMMwqh4qBy09yXYkJdQ=",
       "dev": true,
       "requires": {
-        "graceful-readlink": "1.0.1"
+        "graceful-readlink": ">= 1.0.0"
       }
     },
     "compare-versions": {
@@ -930,8 +930,8 @@
       "integrity": "sha1-q6CXR9++TD5w52am5BWG4YWfxvI=",
       "dev": true,
       "requires": {
-        "ini": "1.3.5",
-        "proto-list": "1.2.4"
+        "ini": "^1.3.4",
+        "proto-list": "~1.2.1"
       }
     },
     "content-disposition": {
@@ -970,9 +970,9 @@
       "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
       "dev": true,
       "requires": {
-        "lru-cache": "4.1.3",
-        "shebang-command": "1.2.0",
-        "which": "1.3.1"
+        "lru-cache": "^4.0.1",
+        "shebang-command": "^1.2.0",
+        "which": "^1.2.9"
       }
     },
     "cssom": {
@@ -987,7 +987,7 @@
       "integrity": "sha512-tNvaxM5blOnxanyxI6panOsnfiyLRj3HV4qjqqS45WPNS1usdYWRUQjqTEEELK73lpeP/1KoIGYUwrBn/VcECA==",
       "dev": true,
       "requires": {
-        "cssom": "0.3.2"
+        "cssom": "0.3.x"
       }
     },
     "dashdash": {
@@ -996,7 +996,7 @@
       "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
       "dev": true,
       "requires": {
-        "assert-plus": "1.0.0"
+        "assert-plus": "^1.0.0"
       }
     },
     "data-urls": {
@@ -1005,9 +1005,9 @@
       "integrity": "sha512-ai40PPQR0Fn1lD2PPie79CibnlMN2AYiDhwFX/rZHVsxbs5kNJSjegqXIprhouGXlRdEnfybva7kqRGnB6mypA==",
       "dev": true,
       "requires": {
-        "abab": "1.0.4",
-        "whatwg-mimetype": "2.1.0",
-        "whatwg-url": "6.5.0"
+        "abab": "^1.0.4",
+        "whatwg-mimetype": "^2.0.0",
+        "whatwg-url": "^6.4.0"
       }
     },
     "debug": {
@@ -1037,14 +1037,14 @@
       "integrity": "sha1-eu3YVCflqS2s/lVnSnxQXpbQH50=",
       "dev": true,
       "requires": {
-        "decompress-tar": "4.1.1",
-        "decompress-tarbz2": "4.1.1",
-        "decompress-targz": "4.1.1",
-        "decompress-unzip": "4.0.1",
-        "graceful-fs": "4.1.11",
-        "make-dir": "1.3.0",
-        "pify": "2.3.0",
-        "strip-dirs": "2.1.0"
+        "decompress-tar": "^4.0.0",
+        "decompress-tarbz2": "^4.0.0",
+        "decompress-targz": "^4.0.0",
+        "decompress-unzip": "^4.0.1",
+        "graceful-fs": "^4.1.10",
+        "make-dir": "^1.0.0",
+        "pify": "^2.3.0",
+        "strip-dirs": "^2.0.0"
       },
       "dependencies": {
         "pify": {
@@ -1061,7 +1061,7 @@
       "integrity": "sha1-gKTdMjdIOEv6JICDYirt7Jgq3/M=",
       "dev": true,
       "requires": {
-        "mimic-response": "1.0.0"
+        "mimic-response": "^1.0.0"
       }
     },
     "decompress-tar": {
@@ -1070,9 +1070,9 @@
       "integrity": "sha512-JdJMaCrGpB5fESVyxwpCx4Jdj2AagLmv3y58Qy4GE6HMVjWz1FeVQk1Ct4Kye7PftcdOo/7U7UKzYBJgqnGeUQ==",
       "dev": true,
       "requires": {
-        "file-type": "5.2.0",
-        "is-stream": "1.1.0",
-        "tar-stream": "1.6.1"
+        "file-type": "^5.2.0",
+        "is-stream": "^1.1.0",
+        "tar-stream": "^1.5.2"
       },
       "dependencies": {
         "file-type": {
@@ -1089,11 +1089,11 @@
       "integrity": "sha512-s88xLzf1r81ICXLAVQVzaN6ZmX4A6U4z2nMbOwobxkLoIIfjVMBg7TeguTUXkKeXni795B6y5rnvDw7rxhAq9A==",
       "dev": true,
       "requires": {
-        "decompress-tar": "4.1.1",
-        "file-type": "6.2.0",
-        "is-stream": "1.1.0",
-        "seek-bzip": "1.0.5",
-        "unbzip2-stream": "1.2.5"
+        "decompress-tar": "^4.1.0",
+        "file-type": "^6.1.0",
+        "is-stream": "^1.1.0",
+        "seek-bzip": "^1.0.5",
+        "unbzip2-stream": "^1.0.9"
       },
       "dependencies": {
         "file-type": {
@@ -1110,9 +1110,9 @@
       "integrity": "sha512-4z81Znfr6chWnRDNfFNqLwPvm4db3WuZkqV+UgXQzSngG3CEKdBkw5jrv3axjjL96glyiiKjsxJG3X6WBZwX3w==",
       "dev": true,
       "requires": {
-        "decompress-tar": "4.1.1",
-        "file-type": "5.2.0",
-        "is-stream": "1.1.0"
+        "decompress-tar": "^4.1.1",
+        "file-type": "^5.2.0",
+        "is-stream": "^1.1.0"
       },
       "dependencies": {
         "file-type": {
@@ -1129,10 +1129,10 @@
       "integrity": "sha1-3qrM39FK6vhVePczroIQ+bSEj2k=",
       "dev": true,
       "requires": {
-        "file-type": "3.9.0",
-        "get-stream": "2.3.1",
-        "pify": "2.3.0",
-        "yauzl": "2.9.2"
+        "file-type": "^3.8.0",
+        "get-stream": "^2.2.0",
+        "pify": "^2.3.0",
+        "yauzl": "^2.4.2"
       },
       "dependencies": {
         "file-type": {
@@ -1147,8 +1147,8 @@
           "integrity": "sha1-Xzj5PzRgCWZu4BUKBUFn+Rvdld4=",
           "dev": true,
           "requires": {
-            "object-assign": "4.1.1",
-            "pinkie-promise": "2.0.1"
+            "object-assign": "^4.0.1",
+            "pinkie-promise": "^2.0.0"
           }
         },
         "pify": {
@@ -1171,7 +1171,7 @@
       "integrity": "sha1-9fj7sYp9bVCyH2QfZJ67Uiz+JPc=",
       "dev": true,
       "requires": {
-        "strip-bom": "3.0.0"
+        "strip-bom": "^3.0.0"
       }
     },
     "define-properties": {
@@ -1180,8 +1180,8 @@
       "integrity": "sha1-g6c/L+pWmJj7c3GTyPhzyvbUXJQ=",
       "dev": true,
       "requires": {
-        "foreach": "2.0.5",
-        "object-keys": "1.0.12"
+        "foreach": "^2.0.5",
+        "object-keys": "^1.0.8"
       }
     },
     "define-property": {
@@ -1190,8 +1190,8 @@
       "integrity": "sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==",
       "dev": true,
       "requires": {
-        "is-descriptor": "1.0.2",
-        "isobject": "3.0.1"
+        "is-descriptor": "^1.0.2",
+        "isobject": "^3.0.1"
       },
       "dependencies": {
         "is-accessor-descriptor": {
@@ -1200,7 +1200,7 @@
           "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
           "dev": true,
           "requires": {
-            "kind-of": "6.0.2"
+            "kind-of": "^6.0.0"
           }
         },
         "is-data-descriptor": {
@@ -1209,7 +1209,7 @@
           "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
           "dev": true,
           "requires": {
-            "kind-of": "6.0.2"
+            "kind-of": "^6.0.0"
           }
         },
         "is-descriptor": {
@@ -1218,9 +1218,9 @@
           "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
           "dev": true,
           "requires": {
-            "is-accessor-descriptor": "1.0.0",
-            "is-data-descriptor": "1.0.0",
-            "kind-of": "6.0.2"
+            "is-accessor-descriptor": "^1.0.0",
+            "is-data-descriptor": "^1.0.0",
+            "kind-of": "^6.0.2"
           }
         },
         "kind-of": {
@@ -1243,7 +1243,7 @@
       "integrity": "sha1-920GQ1LN9Docts5hnE7jqUdd4gg=",
       "dev": true,
       "requires": {
-        "repeating": "2.0.1"
+        "repeating": "^2.0.0"
       }
     },
     "detect-newline": {
@@ -1264,7 +1264,7 @@
       "integrity": "sha512-raigMkn7CJNNo6Ihro1fzG7wr3fHuYVytzquZKX5n0yizGsTcYgzdIUwj1X9pK0VvjeihV+XiclP+DjwbsSKug==",
       "dev": true,
       "requires": {
-        "webidl-conversions": "4.0.2"
+        "webidl-conversions": "^4.0.2"
       }
     },
     "download": {
@@ -1273,17 +1273,17 @@
       "integrity": "sha512-0Fe/CAjKycx12IG9We9gYlLP03BEcWTpttg7P5mwfOiQTg584kpuHqP7F61RkUJM+mfEdEU9TJonm0PJp5rQLw==",
       "dev": true,
       "requires": {
-        "caw": "2.0.1",
-        "content-disposition": "0.5.2",
-        "decompress": "4.2.0",
-        "ext-name": "5.0.0",
-        "file-type": "7.7.1",
-        "filenamify": "2.1.0",
-        "get-stream": "3.0.0",
-        "got": "8.3.1",
-        "make-dir": "1.3.0",
-        "p-event": "1.3.0",
-        "pify": "3.0.0"
+        "caw": "^2.0.1",
+        "content-disposition": "^0.5.2",
+        "decompress": "^4.2.0",
+        "ext-name": "^5.0.0",
+        "file-type": "^7.7.1",
+        "filenamify": "^2.0.0",
+        "get-stream": "^3.0.0",
+        "got": "^8.3.1",
+        "make-dir": "^1.2.0",
+        "p-event": "^1.3.0",
+        "pify": "^3.0.0"
       }
     },
     "duplexer3": {
@@ -1299,7 +1299,7 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "jsbn": "0.1.1"
+        "jsbn": "~0.1.0"
       }
     },
     "end-of-stream": {
@@ -1308,7 +1308,7 @@
       "integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
       "dev": true,
       "requires": {
-        "once": "1.4.0"
+        "once": "^1.4.0"
       }
     },
     "error-ex": {
@@ -1317,7 +1317,7 @@
       "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
       "dev": true,
       "requires": {
-        "is-arrayish": "0.2.1"
+        "is-arrayish": "^0.2.1"
       }
     },
     "es-abstract": {
@@ -1326,11 +1326,11 @@
       "integrity": "sha512-C8Fx/0jFmV5IPoMOFPA9P9G5NtqW+4cOPit3MIuvR2t7Ag2K15EJTpxnHAYTzL+aYQJIESYeXZmDBfOBE1HcpA==",
       "dev": true,
       "requires": {
-        "es-to-primitive": "1.1.1",
-        "function-bind": "1.1.1",
-        "has": "1.0.3",
-        "is-callable": "1.1.3",
-        "is-regex": "1.0.4"
+        "es-to-primitive": "^1.1.1",
+        "function-bind": "^1.1.1",
+        "has": "^1.0.1",
+        "is-callable": "^1.1.3",
+        "is-regex": "^1.0.4"
       }
     },
     "es-to-primitive": {
@@ -1339,9 +1339,9 @@
       "integrity": "sha1-RTVSSKiJeQNLZ5Lhm7gfK3l13Q0=",
       "dev": true,
       "requires": {
-        "is-callable": "1.1.3",
-        "is-date-object": "1.0.1",
-        "is-symbol": "1.0.1"
+        "is-callable": "^1.1.1",
+        "is-date-object": "^1.0.1",
+        "is-symbol": "^1.0.1"
       }
     },
     "escape-string-regexp": {
@@ -1356,11 +1356,11 @@
       "integrity": "sha512-fjUOf8johsv23WuIKdNQU4P9t9jhQ4Qzx6pC2uW890OloK3Zs1ZAoCNpg/2larNF501jLl3UNy0kIRcF6VI22g==",
       "dev": true,
       "requires": {
-        "esprima": "3.1.3",
-        "estraverse": "4.2.0",
-        "esutils": "2.0.2",
-        "optionator": "0.8.2",
-        "source-map": "0.6.1"
+        "esprima": "^3.1.3",
+        "estraverse": "^4.2.0",
+        "esutils": "^2.0.2",
+        "optionator": "^0.8.1",
+        "source-map": "~0.6.1"
       },
       "dependencies": {
         "esprima": {
@@ -1402,7 +1402,7 @@
       "integrity": "sha512-aLt95pexaugVtQerpmE51+4QfWrNc304uez7jvj6fWnN8GeEHpttB8F36n8N7uVhUMbH/1enbxQ9HImZ4w/9qg==",
       "dev": true,
       "requires": {
-        "merge": "1.2.0"
+        "merge": "^1.1.3"
       }
     },
     "execa": {
@@ -1411,13 +1411,13 @@
       "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
       "dev": true,
       "requires": {
-        "cross-spawn": "5.1.0",
-        "get-stream": "3.0.0",
-        "is-stream": "1.1.0",
-        "npm-run-path": "2.0.2",
-        "p-finally": "1.0.0",
-        "signal-exit": "3.0.2",
-        "strip-eof": "1.0.0"
+        "cross-spawn": "^5.0.1",
+        "get-stream": "^3.0.0",
+        "is-stream": "^1.1.0",
+        "npm-run-path": "^2.0.0",
+        "p-finally": "^1.0.0",
+        "signal-exit": "^3.0.0",
+        "strip-eof": "^1.0.0"
       }
     },
     "exit": {
@@ -1432,13 +1432,13 @@
       "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
       "dev": true,
       "requires": {
-        "debug": "2.6.9",
-        "define-property": "0.2.5",
-        "extend-shallow": "2.0.1",
-        "posix-character-classes": "0.1.1",
-        "regex-not": "1.0.2",
-        "snapdragon": "0.8.2",
-        "to-regex": "3.0.2"
+        "debug": "^2.3.3",
+        "define-property": "^0.2.5",
+        "extend-shallow": "^2.0.1",
+        "posix-character-classes": "^0.1.0",
+        "regex-not": "^1.0.0",
+        "snapdragon": "^0.8.1",
+        "to-regex": "^3.0.1"
       },
       "dependencies": {
         "define-property": {
@@ -1447,7 +1447,7 @@
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "dev": true,
           "requires": {
-            "is-descriptor": "0.1.6"
+            "is-descriptor": "^0.1.0"
           }
         },
         "extend-shallow": {
@@ -1456,7 +1456,7 @@
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "dev": true,
           "requires": {
-            "is-extendable": "0.1.1"
+            "is-extendable": "^0.1.0"
           }
         }
       }
@@ -1467,7 +1467,7 @@
       "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
       "dev": true,
       "requires": {
-        "fill-range": "2.2.4"
+        "fill-range": "^2.1.0"
       },
       "dependencies": {
         "fill-range": {
@@ -1476,11 +1476,11 @@
           "integrity": "sha512-cnrcCbj01+j2gTG921VZPnHbjmdAf8oQV/iGeV2kZxGSyfYjjTyY79ErsK1WJWMpw6DaApEX72binqJE+/d+5Q==",
           "dev": true,
           "requires": {
-            "is-number": "2.1.0",
-            "isobject": "2.1.0",
-            "randomatic": "3.0.0",
-            "repeat-element": "1.1.2",
-            "repeat-string": "1.6.1"
+            "is-number": "^2.1.0",
+            "isobject": "^2.0.0",
+            "randomatic": "^3.0.0",
+            "repeat-element": "^1.1.2",
+            "repeat-string": "^1.5.2"
           }
         },
         "is-number": {
@@ -1489,7 +1489,7 @@
           "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
           "dev": true,
           "requires": {
-            "kind-of": "3.2.2"
+            "kind-of": "^3.0.2"
           }
         },
         "isobject": {
@@ -1509,12 +1509,12 @@
       "integrity": "sha1-v9/VeiogFw2HWZnul4fMcfAcIF8=",
       "dev": true,
       "requires": {
-        "ansi-styles": "3.2.1",
-        "jest-diff": "23.0.1",
-        "jest-get-type": "22.4.3",
-        "jest-matcher-utils": "23.0.1",
-        "jest-message-util": "23.1.0",
-        "jest-regex-util": "23.0.0"
+        "ansi-styles": "^3.2.0",
+        "jest-diff": "^23.0.1",
+        "jest-get-type": "^22.1.0",
+        "jest-matcher-utils": "^23.0.1",
+        "jest-message-util": "^23.1.0",
+        "jest-regex-util": "^23.0.0"
       }
     },
     "ext-list": {
@@ -1523,7 +1523,7 @@
       "integrity": "sha512-u+SQgsubraE6zItfVA0tBuCBhfU9ogSRnsvygI7wht9TS510oLkBRXBsqopeUG/GBOIQyKZO9wjTqIu/sf5zFA==",
       "dev": true,
       "requires": {
-        "mime-db": "1.34.0"
+        "mime-db": "^1.28.0"
       }
     },
     "ext-name": {
@@ -1532,8 +1532,8 @@
       "integrity": "sha512-yblEwXAbGv1VQDmow7s38W77hzAgJAO50ztBLMcUyUBfxv1HC+LGwtiEN+Co6LtlqT/5uwVOxsD4TNIilWhwdQ==",
       "dev": true,
       "requires": {
-        "ext-list": "2.2.2",
-        "sort-keys-length": "1.0.1"
+        "ext-list": "^2.0.0",
+        "sort-keys-length": "^1.0.0"
       }
     },
     "extend": {
@@ -1548,8 +1548,8 @@
       "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
       "dev": true,
       "requires": {
-        "assign-symbols": "1.0.0",
-        "is-extendable": "1.0.1"
+        "assign-symbols": "^1.0.0",
+        "is-extendable": "^1.0.1"
       },
       "dependencies": {
         "is-extendable": {
@@ -1558,7 +1558,7 @@
           "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
           "dev": true,
           "requires": {
-            "is-plain-object": "2.0.4"
+            "is-plain-object": "^2.0.4"
           }
         }
       }
@@ -1569,14 +1569,14 @@
       "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
       "dev": true,
       "requires": {
-        "array-unique": "0.3.2",
-        "define-property": "1.0.0",
-        "expand-brackets": "2.1.4",
-        "extend-shallow": "2.0.1",
-        "fragment-cache": "0.2.1",
-        "regex-not": "1.0.2",
-        "snapdragon": "0.8.2",
-        "to-regex": "3.0.2"
+        "array-unique": "^0.3.2",
+        "define-property": "^1.0.0",
+        "expand-brackets": "^2.1.4",
+        "extend-shallow": "^2.0.1",
+        "fragment-cache": "^0.2.1",
+        "regex-not": "^1.0.0",
+        "snapdragon": "^0.8.1",
+        "to-regex": "^3.0.1"
       },
       "dependencies": {
         "define-property": {
@@ -1585,7 +1585,7 @@
           "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
           "dev": true,
           "requires": {
-            "is-descriptor": "1.0.2"
+            "is-descriptor": "^1.0.0"
           }
         },
         "extend-shallow": {
@@ -1594,7 +1594,7 @@
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "dev": true,
           "requires": {
-            "is-extendable": "0.1.1"
+            "is-extendable": "^0.1.0"
           }
         },
         "is-accessor-descriptor": {
@@ -1603,7 +1603,7 @@
           "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
           "dev": true,
           "requires": {
-            "kind-of": "6.0.2"
+            "kind-of": "^6.0.0"
           }
         },
         "is-data-descriptor": {
@@ -1612,7 +1612,7 @@
           "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
           "dev": true,
           "requires": {
-            "kind-of": "6.0.2"
+            "kind-of": "^6.0.0"
           }
         },
         "is-descriptor": {
@@ -1621,9 +1621,9 @@
           "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
           "dev": true,
           "requires": {
-            "is-accessor-descriptor": "1.0.0",
-            "is-data-descriptor": "1.0.0",
-            "kind-of": "6.0.2"
+            "is-accessor-descriptor": "^1.0.0",
+            "is-data-descriptor": "^1.0.0",
+            "kind-of": "^6.0.2"
           }
         },
         "kind-of": {
@@ -1664,7 +1664,7 @@
       "integrity": "sha1-VOmr99+i8mzZsWNsWIwa/AXeXVg=",
       "dev": true,
       "requires": {
-        "bser": "2.0.0"
+        "bser": "^2.0.0"
       }
     },
     "fd-slicer": {
@@ -1673,7 +1673,7 @@
       "integrity": "sha1-JcfInLH5B3+IkbvmHY85Dq4lbx4=",
       "dev": true,
       "requires": {
-        "pend": "1.2.0"
+        "pend": "~1.2.0"
       }
     },
     "file-type": {
@@ -1700,9 +1700,9 @@
       "integrity": "sha512-ICw7NTT6RsDp2rnYKVd8Fu4cr6ITzGy3+u4vUujPkabyaz+03F24NWEX7fs5fp+kBonlaqPH8fAO2NM+SXt/JA==",
       "dev": true,
       "requires": {
-        "filename-reserved-regex": "2.0.0",
-        "strip-outer": "1.0.1",
-        "trim-repeated": "1.0.0"
+        "filename-reserved-regex": "^2.0.0",
+        "strip-outer": "^1.0.0",
+        "trim-repeated": "^1.0.0"
       }
     },
     "fileset": {
@@ -1711,8 +1711,8 @@
       "integrity": "sha1-jnVIqW08wjJ+5eZ0FocjozO7oqA=",
       "dev": true,
       "requires": {
-        "glob": "7.1.2",
-        "minimatch": "3.0.4"
+        "glob": "^7.0.3",
+        "minimatch": "^3.0.3"
       }
     },
     "fill-range": {
@@ -1721,10 +1721,10 @@
       "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
       "dev": true,
       "requires": {
-        "extend-shallow": "2.0.1",
-        "is-number": "3.0.0",
-        "repeat-string": "1.6.1",
-        "to-regex-range": "2.1.1"
+        "extend-shallow": "^2.0.1",
+        "is-number": "^3.0.0",
+        "repeat-string": "^1.6.1",
+        "to-regex-range": "^2.1.0"
       },
       "dependencies": {
         "extend-shallow": {
@@ -1733,7 +1733,7 @@
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "dev": true,
           "requires": {
-            "is-extendable": "0.1.1"
+            "is-extendable": "^0.1.0"
           }
         }
       }
@@ -1744,7 +1744,7 @@
       "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
       "dev": true,
       "requires": {
-        "locate-path": "2.0.0"
+        "locate-path": "^2.0.0"
       }
     },
     "for-in": {
@@ -1759,7 +1759,7 @@
       "integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
       "dev": true,
       "requires": {
-        "for-in": "1.0.2"
+        "for-in": "^1.0.1"
       }
     },
     "foreach": {
@@ -1780,9 +1780,9 @@
       "integrity": "sha1-SXBJi+YEwgwAXU9cI67NIda0kJk=",
       "dev": true,
       "requires": {
-        "asynckit": "0.4.0",
+        "asynckit": "^0.4.0",
         "combined-stream": "1.0.6",
-        "mime-types": "2.1.18"
+        "mime-types": "^2.1.12"
       }
     },
     "fragment-cache": {
@@ -1791,7 +1791,7 @@
       "integrity": "sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=",
       "dev": true,
       "requires": {
-        "map-cache": "0.2.2"
+        "map-cache": "^0.2.2"
       }
     },
     "from2": {
@@ -1800,8 +1800,8 @@
       "integrity": "sha1-i/tVAr3kpNNs/e6gB/zKIdfjgq8=",
       "dev": true,
       "requires": {
-        "inherits": "2.0.3",
-        "readable-stream": "2.3.6"
+        "inherits": "^2.0.1",
+        "readable-stream": "^2.0.0"
       }
     },
     "fs-constants": {
@@ -1810,11 +1810,551 @@
       "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
       "dev": true
     },
+    "fs-extra": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.0.tgz",
+      "integrity": "sha512-EglNDLRpmaTWiD/qraZn6HREAEAHJcJOmxNEYwq6xeMKnVMAy3GUcFB+wXt2C6k4CNvB/mP1y/U3dzvKKj5OtQ==",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "^4.1.2",
+        "jsonfile": "^4.0.0",
+        "universalify": "^0.1.0"
+      }
+    },
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
       "dev": true
+    },
+    "fsevents": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.4.tgz",
+      "integrity": "sha512-z8H8/diyk76B7q5wg+Ud0+CqzcAF3mBBI/bA5ne5zrRUUIvNkJY//D3BqyH571KuAC4Nr7Rw7CjWX4r0y9DvNg==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "nan": "^2.9.2",
+        "node-pre-gyp": "^0.10.0"
+      },
+      "dependencies": {
+        "abbrev": {
+          "version": "1.1.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "ansi-regex": {
+          "version": "2.1.1",
+          "bundled": true,
+          "dev": true
+        },
+        "aproba": {
+          "version": "1.2.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "are-we-there-yet": {
+          "version": "1.1.4",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "delegates": "^1.0.0",
+            "readable-stream": "^2.0.6"
+          }
+        },
+        "balanced-match": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "brace-expansion": {
+          "version": "1.1.11",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "balanced-match": "^1.0.0",
+            "concat-map": "0.0.1"
+          }
+        },
+        "chownr": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "code-point-at": {
+          "version": "1.1.0",
+          "bundled": true,
+          "dev": true
+        },
+        "concat-map": {
+          "version": "0.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "console-control-strings": {
+          "version": "1.1.0",
+          "bundled": true,
+          "dev": true
+        },
+        "core-util-is": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "debug": {
+          "version": "2.6.9",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "deep-extend": {
+          "version": "0.5.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "delegates": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "detect-libc": {
+          "version": "1.0.3",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "fs-minipass": {
+          "version": "1.2.5",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "minipass": "^2.2.1"
+          }
+        },
+        "fs.realpath": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "gauge": {
+          "version": "2.7.4",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "aproba": "^1.0.3",
+            "console-control-strings": "^1.0.0",
+            "has-unicode": "^2.0.0",
+            "object-assign": "^4.1.0",
+            "signal-exit": "^3.0.0",
+            "string-width": "^1.0.1",
+            "strip-ansi": "^3.0.1",
+            "wide-align": "^1.1.0"
+          }
+        },
+        "glob": {
+          "version": "7.1.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        },
+        "has-unicode": {
+          "version": "2.0.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "iconv-lite": {
+          "version": "0.4.21",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "safer-buffer": "^2.1.0"
+          }
+        },
+        "ignore-walk": {
+          "version": "3.0.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "minimatch": "^3.0.4"
+          }
+        },
+        "inflight": {
+          "version": "1.0.6",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "once": "^1.3.0",
+            "wrappy": "1"
+          }
+        },
+        "inherits": {
+          "version": "2.0.3",
+          "bundled": true,
+          "dev": true
+        },
+        "ini": {
+          "version": "1.3.5",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "number-is-nan": "^1.0.0"
+          }
+        },
+        "isarray": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "minimatch": {
+          "version": "3.0.4",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "brace-expansion": "^1.1.7"
+          }
+        },
+        "minimist": {
+          "version": "0.0.8",
+          "bundled": true,
+          "dev": true
+        },
+        "minipass": {
+          "version": "2.2.4",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "safe-buffer": "^5.1.1",
+            "yallist": "^3.0.0"
+          }
+        },
+        "minizlib": {
+          "version": "1.1.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "minipass": "^2.2.1"
+          }
+        },
+        "mkdirp": {
+          "version": "0.5.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "minimist": "0.0.8"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "needle": {
+          "version": "2.2.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "debug": "^2.1.2",
+            "iconv-lite": "^0.4.4",
+            "sax": "^1.2.4"
+          }
+        },
+        "node-pre-gyp": {
+          "version": "0.10.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "detect-libc": "^1.0.2",
+            "mkdirp": "^0.5.1",
+            "needle": "^2.2.0",
+            "nopt": "^4.0.1",
+            "npm-packlist": "^1.1.6",
+            "npmlog": "^4.0.2",
+            "rc": "^1.1.7",
+            "rimraf": "^2.6.1",
+            "semver": "^5.3.0",
+            "tar": "^4"
+          }
+        },
+        "nopt": {
+          "version": "4.0.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "abbrev": "1",
+            "osenv": "^0.1.4"
+          }
+        },
+        "npm-bundled": {
+          "version": "1.0.3",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "npm-packlist": {
+          "version": "1.1.10",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "ignore-walk": "^3.0.1",
+            "npm-bundled": "^1.0.1"
+          }
+        },
+        "npmlog": {
+          "version": "4.1.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "are-we-there-yet": "~1.1.2",
+            "console-control-strings": "~1.1.0",
+            "gauge": "~2.7.3",
+            "set-blocking": "~2.0.0"
+          }
+        },
+        "number-is-nan": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "object-assign": {
+          "version": "4.1.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "once": {
+          "version": "1.4.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "wrappy": "1"
+          }
+        },
+        "os-homedir": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "os-tmpdir": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "osenv": {
+          "version": "0.1.5",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "os-homedir": "^1.0.0",
+            "os-tmpdir": "^1.0.0"
+          }
+        },
+        "path-is-absolute": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "process-nextick-args": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "rc": {
+          "version": "1.2.7",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "deep-extend": "^0.5.1",
+            "ini": "~1.3.0",
+            "minimist": "^1.2.0",
+            "strip-json-comments": "~2.0.1"
+          },
+          "dependencies": {
+            "minimist": {
+              "version": "1.2.0",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            }
+          }
+        },
+        "readable-stream": {
+          "version": "2.3.6",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
+          }
+        },
+        "rimraf": {
+          "version": "2.6.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "glob": "^7.0.5"
+          }
+        },
+        "safe-buffer": {
+          "version": "5.1.1",
+          "bundled": true,
+          "dev": true
+        },
+        "safer-buffer": {
+          "version": "2.1.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "sax": {
+          "version": "1.2.4",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "semver": {
+          "version": "5.5.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "set-blocking": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "signal-exit": {
+          "version": "3.0.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "string-width": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "code-point-at": "^1.0.0",
+            "is-fullwidth-code-point": "^1.0.0",
+            "strip-ansi": "^3.0.0"
+          }
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "safe-buffer": "~5.1.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^2.0.0"
+          }
+        },
+        "strip-json-comments": {
+          "version": "2.0.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "tar": {
+          "version": "4.4.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "chownr": "^1.0.1",
+            "fs-minipass": "^1.2.5",
+            "minipass": "^2.2.4",
+            "minizlib": "^1.1.0",
+            "mkdirp": "^0.5.0",
+            "safe-buffer": "^5.1.1",
+            "yallist": "^3.0.2"
+          }
+        },
+        "util-deprecate": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "wide-align": {
+          "version": "1.1.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "string-width": "^1.0.2"
+          }
+        },
+        "wrappy": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true
+        },
+        "yallist": {
+          "version": "3.0.2",
+          "bundled": true,
+          "dev": true
+        }
+      }
     },
     "function-bind": {
       "version": "1.1.1",
@@ -1834,7 +2374,7 @@
       "integrity": "sha512-zmZIaQTWnNQb4R4fJUEp/FC51eZsc6EkErspy3xtIYStaq8EB/hDIWipxsal+E8rz0qD7f2sL/NA9Xee4RInJw==",
       "dev": true,
       "requires": {
-        "npm-conf": "1.1.3"
+        "npm-conf": "^1.1.0"
       }
     },
     "get-stream": {
@@ -1855,7 +2395,7 @@
       "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
       "dev": true,
       "requires": {
-        "assert-plus": "1.0.0"
+        "assert-plus": "^1.0.0"
       }
     },
     "glob": {
@@ -1864,12 +2404,12 @@
       "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
       "dev": true,
       "requires": {
-        "fs.realpath": "1.0.0",
-        "inflight": "1.0.6",
-        "inherits": "2.0.3",
-        "minimatch": "3.0.4",
-        "once": "1.4.0",
-        "path-is-absolute": "1.0.1"
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
       }
     },
     "glob-base": {
@@ -1878,8 +2418,8 @@
       "integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
       "dev": true,
       "requires": {
-        "glob-parent": "2.0.0",
-        "is-glob": "2.0.1"
+        "glob-parent": "^2.0.0",
+        "is-glob": "^2.0.0"
       }
     },
     "glob-parent": {
@@ -1888,7 +2428,7 @@
       "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
       "dev": true,
       "requires": {
-        "is-glob": "2.0.1"
+        "is-glob": "^2.0.0"
       }
     },
     "globals": {
@@ -1903,23 +2443,23 @@
       "integrity": "sha512-tiLX+bnYm5A56T5N/n9Xo89vMaO1mrS9qoDqj3u/anVooqGozvY/HbXzEpDfbNeKsHCBpK40gSbz8wGYSp3i1w==",
       "dev": true,
       "requires": {
-        "@sindresorhus/is": "0.7.0",
-        "cacheable-request": "2.1.4",
-        "decompress-response": "3.3.0",
-        "duplexer3": "0.1.4",
-        "get-stream": "3.0.0",
-        "into-stream": "3.1.0",
-        "is-retry-allowed": "1.1.0",
-        "isurl": "1.0.0",
-        "lowercase-keys": "1.0.1",
-        "mimic-response": "1.0.0",
-        "p-cancelable": "0.4.1",
-        "p-timeout": "2.0.1",
-        "pify": "3.0.0",
-        "safe-buffer": "5.1.2",
-        "timed-out": "4.0.1",
-        "url-parse-lax": "3.0.0",
-        "url-to-options": "1.0.1"
+        "@sindresorhus/is": "^0.7.0",
+        "cacheable-request": "^2.1.1",
+        "decompress-response": "^3.3.0",
+        "duplexer3": "^0.1.4",
+        "get-stream": "^3.0.0",
+        "into-stream": "^3.1.0",
+        "is-retry-allowed": "^1.1.0",
+        "isurl": "^1.0.0-alpha5",
+        "lowercase-keys": "^1.0.0",
+        "mimic-response": "^1.0.0",
+        "p-cancelable": "^0.4.0",
+        "p-timeout": "^2.0.1",
+        "pify": "^3.0.0",
+        "safe-buffer": "^5.1.1",
+        "timed-out": "^4.0.1",
+        "url-parse-lax": "^3.0.0",
+        "url-to-options": "^1.0.1"
       }
     },
     "graceful-fs": {
@@ -1946,10 +2486,10 @@
       "integrity": "sha1-Ywo13+ApS8KB7a5v/F0yn8eYLcw=",
       "dev": true,
       "requires": {
-        "async": "1.5.2",
-        "optimist": "0.6.1",
-        "source-map": "0.4.4",
-        "uglify-js": "2.8.29"
+        "async": "^1.4.0",
+        "optimist": "^0.6.1",
+        "source-map": "^0.4.4",
+        "uglify-js": "^2.6"
       },
       "dependencies": {
         "async": {
@@ -1964,7 +2504,7 @@
           "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
           "dev": true,
           "requires": {
-            "amdefine": "1.0.1"
+            "amdefine": ">=0.0.4"
           }
         }
       }
@@ -1981,8 +2521,8 @@
       "integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
       "dev": true,
       "requires": {
-        "ajv": "5.5.2",
-        "har-schema": "2.0.0"
+        "ajv": "^5.1.0",
+        "har-schema": "^2.0.0"
       }
     },
     "has": {
@@ -1991,7 +2531,7 @@
       "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
       "dev": true,
       "requires": {
-        "function-bind": "1.1.1"
+        "function-bind": "^1.1.1"
       }
     },
     "has-ansi": {
@@ -2000,7 +2540,7 @@
       "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
       "dev": true,
       "requires": {
-        "ansi-regex": "2.1.1"
+        "ansi-regex": "^2.0.0"
       }
     },
     "has-flag": {
@@ -2021,7 +2561,7 @@
       "integrity": "sha512-vdbKfmw+3LoOYVr+mtxHaX5a96+0f3DljYd8JOqvOLsf5mw2Otda2qCDT9qRqLAhrjyQ0h7ual5nOiASpsGNFw==",
       "dev": true,
       "requires": {
-        "has-symbol-support-x": "1.4.2"
+        "has-symbol-support-x": "^1.4.1"
       }
     },
     "has-value": {
@@ -2030,9 +2570,9 @@
       "integrity": "sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=",
       "dev": true,
       "requires": {
-        "get-value": "2.0.6",
-        "has-values": "1.0.0",
-        "isobject": "3.0.1"
+        "get-value": "^2.0.6",
+        "has-values": "^1.0.0",
+        "isobject": "^3.0.0"
       }
     },
     "has-values": {
@@ -2041,8 +2581,8 @@
       "integrity": "sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=",
       "dev": true,
       "requires": {
-        "is-number": "3.0.0",
-        "kind-of": "4.0.0"
+        "is-number": "^3.0.0",
+        "kind-of": "^4.0.0"
       },
       "dependencies": {
         "kind-of": {
@@ -2051,7 +2591,7 @@
           "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
           "dev": true,
           "requires": {
-            "is-buffer": "1.1.6"
+            "is-buffer": "^1.1.5"
           }
         }
       }
@@ -2062,8 +2602,8 @@
       "integrity": "sha1-42w/LSyufXRqhX440Y1fMqeILbg=",
       "dev": true,
       "requires": {
-        "os-homedir": "1.0.2",
-        "os-tmpdir": "1.0.2"
+        "os-homedir": "^1.0.0",
+        "os-tmpdir": "^1.0.1"
       }
     },
     "hosted-git-info": {
@@ -2078,7 +2618,7 @@
       "integrity": "sha512-71lZziiDnsuabfdYiUeWdCVyKuqwWi23L8YeIgV9jSSZHCtb6wB1BKWooH7L3tn4/FuZJMVWyNaIDr4RGmaSYw==",
       "dev": true,
       "requires": {
-        "whatwg-encoding": "1.0.3"
+        "whatwg-encoding": "^1.0.1"
       }
     },
     "http-cache-semantics": {
@@ -2093,9 +2633,9 @@
       "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
       "dev": true,
       "requires": {
-        "assert-plus": "1.0.0",
-        "jsprim": "1.4.1",
-        "sshpk": "1.14.2"
+        "assert-plus": "^1.0.0",
+        "jsprim": "^1.2.2",
+        "sshpk": "^1.7.0"
       }
     },
     "iconv-lite": {
@@ -2116,8 +2656,8 @@
       "integrity": "sha512-vAaZHieK9qjGo58agRBg+bhHX3hoTZU/Oa3GESWLz7t1U62fk63aHuDJJEteXoDeTCcPmUT+z38gkHPZkkmpmQ==",
       "dev": true,
       "requires": {
-        "pkg-dir": "2.0.0",
-        "resolve-cwd": "2.0.0"
+        "pkg-dir": "^2.0.0",
+        "resolve-cwd": "^2.0.0"
       }
     },
     "imurmurhash": {
@@ -2132,8 +2672,8 @@
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
       "dev": true,
       "requires": {
-        "once": "1.4.0",
-        "wrappy": "1.0.2"
+        "once": "^1.3.0",
+        "wrappy": "1"
       }
     },
     "inherits": {
@@ -2154,8 +2694,8 @@
       "integrity": "sha1-lvsKk2wSur1v8XUqF9BWFqvQlMY=",
       "dev": true,
       "requires": {
-        "from2": "2.3.0",
-        "p-is-promise": "1.1.0"
+        "from2": "^2.1.1",
+        "p-is-promise": "^1.1.0"
       }
     },
     "invariant": {
@@ -2164,7 +2704,7 @@
       "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
       "dev": true,
       "requires": {
-        "loose-envify": "1.3.1"
+        "loose-envify": "^1.0.0"
       }
     },
     "invert-kv": {
@@ -2179,7 +2719,7 @@
       "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
       "dev": true,
       "requires": {
-        "kind-of": "3.2.2"
+        "kind-of": "^3.0.2"
       }
     },
     "is-arrayish": {
@@ -2200,7 +2740,7 @@
       "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
       "dev": true,
       "requires": {
-        "builtin-modules": "1.1.1"
+        "builtin-modules": "^1.0.0"
       }
     },
     "is-callable": {
@@ -2215,7 +2755,7 @@
       "integrity": "sha512-c7TnwxLePuqIlxHgr7xtxzycJPegNHFuIrBkwbf8hc58//+Op1CqFkyS+xnIMkwn9UsJIwc174BIjkyBmSpjKg==",
       "dev": true,
       "requires": {
-        "ci-info": "1.1.3"
+        "ci-info": "^1.0.0"
       }
     },
     "is-data-descriptor": {
@@ -2224,7 +2764,7 @@
       "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
       "dev": true,
       "requires": {
-        "kind-of": "3.2.2"
+        "kind-of": "^3.0.2"
       }
     },
     "is-date-object": {
@@ -2239,9 +2779,9 @@
       "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
       "dev": true,
       "requires": {
-        "is-accessor-descriptor": "0.1.6",
-        "is-data-descriptor": "0.1.4",
-        "kind-of": "5.1.0"
+        "is-accessor-descriptor": "^0.1.6",
+        "is-data-descriptor": "^0.1.4",
+        "kind-of": "^5.0.0"
       },
       "dependencies": {
         "kind-of": {
@@ -2264,7 +2804,7 @@
       "integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
       "dev": true,
       "requires": {
-        "is-primitive": "2.0.0"
+        "is-primitive": "^2.0.0"
       }
     },
     "is-extendable": {
@@ -2285,7 +2825,7 @@
       "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
       "dev": true,
       "requires": {
-        "number-is-nan": "1.0.1"
+        "number-is-nan": "^1.0.0"
       }
     },
     "is-fullwidth-code-point": {
@@ -2306,7 +2846,7 @@
       "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
       "dev": true,
       "requires": {
-        "is-extglob": "1.0.0"
+        "is-extglob": "^1.0.0"
       }
     },
     "is-natural-number": {
@@ -2321,7 +2861,7 @@
       "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
       "dev": true,
       "requires": {
-        "kind-of": "3.2.2"
+        "kind-of": "^3.0.2"
       }
     },
     "is-object": {
@@ -2336,7 +2876,7 @@
       "integrity": "sha512-OTiixgpZAT1M4NHgS5IguFp/Vz2VI3U7Goh4/HA1adtwyLtSBrxYlcSYkhpAE07s4fKEcjrFxyvtQBND4vFQyQ==",
       "dev": true,
       "requires": {
-        "is-number": "4.0.0"
+        "is-number": "^4.0.0"
       },
       "dependencies": {
         "is-number": {
@@ -2359,7 +2899,7 @@
       "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
       "dev": true,
       "requires": {
-        "isobject": "3.0.1"
+        "isobject": "^3.0.1"
       }
     },
     "is-posix-bracket": {
@@ -2380,7 +2920,7 @@
       "integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
       "dev": true,
       "requires": {
-        "has": "1.0.3"
+        "has": "^1.0.1"
       }
     },
     "is-retry-allowed": {
@@ -2449,18 +2989,18 @@
       "integrity": "sha512-duj6AlLcsWNwUpfyfHt0nWIeRiZpuShnP40YTxOGQgtaN8fd6JYSxsvxUphTDy8V5MfDXo4s/xVCIIvVCO808g==",
       "dev": true,
       "requires": {
-        "async": "2.6.1",
-        "compare-versions": "3.3.0",
-        "fileset": "2.0.3",
-        "istanbul-lib-coverage": "1.2.0",
-        "istanbul-lib-hook": "1.2.1",
-        "istanbul-lib-instrument": "1.10.1",
-        "istanbul-lib-report": "1.1.4",
-        "istanbul-lib-source-maps": "1.2.5",
-        "istanbul-reports": "1.3.0",
-        "js-yaml": "3.12.0",
-        "mkdirp": "0.5.1",
-        "once": "1.4.0"
+        "async": "^2.1.4",
+        "compare-versions": "^3.1.0",
+        "fileset": "^2.0.2",
+        "istanbul-lib-coverage": "^1.2.0",
+        "istanbul-lib-hook": "^1.2.0",
+        "istanbul-lib-instrument": "^1.10.1",
+        "istanbul-lib-report": "^1.1.4",
+        "istanbul-lib-source-maps": "^1.2.4",
+        "istanbul-reports": "^1.3.0",
+        "js-yaml": "^3.7.0",
+        "mkdirp": "^0.5.1",
+        "once": "^1.4.0"
       }
     },
     "istanbul-lib-coverage": {
@@ -2475,7 +3015,7 @@
       "integrity": "sha512-eLAMkPG9FU0v5L02lIkcj/2/Zlz9OuluaXikdr5iStk8FDbSwAixTK9TkYxbF0eNnzAJTwM2fkV2A1tpsIp4Jg==",
       "dev": true,
       "requires": {
-        "append-transform": "1.0.0"
+        "append-transform": "^1.0.0"
       }
     },
     "istanbul-lib-instrument": {
@@ -2484,13 +3024,13 @@
       "integrity": "sha512-1dYuzkOCbuR5GRJqySuZdsmsNKPL3PTuyPevQfoCXJePT9C8y1ga75neU+Tuy9+yS3G/dgx8wgOmp2KLpgdoeQ==",
       "dev": true,
       "requires": {
-        "babel-generator": "6.26.1",
-        "babel-template": "6.26.0",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0",
-        "babylon": "6.18.0",
-        "istanbul-lib-coverage": "1.2.0",
-        "semver": "5.5.0"
+        "babel-generator": "^6.18.0",
+        "babel-template": "^6.16.0",
+        "babel-traverse": "^6.18.0",
+        "babel-types": "^6.18.0",
+        "babylon": "^6.18.0",
+        "istanbul-lib-coverage": "^1.2.0",
+        "semver": "^5.3.0"
       }
     },
     "istanbul-lib-report": {
@@ -2499,10 +3039,10 @@
       "integrity": "sha512-Azqvq5tT0U09nrncK3q82e/Zjkxa4tkFZv7E6VcqP0QCPn6oNljDPfrZEC/umNXds2t7b8sRJfs6Kmpzt8m2kA==",
       "dev": true,
       "requires": {
-        "istanbul-lib-coverage": "1.2.0",
-        "mkdirp": "0.5.1",
-        "path-parse": "1.0.5",
-        "supports-color": "3.2.3"
+        "istanbul-lib-coverage": "^1.2.0",
+        "mkdirp": "^0.5.1",
+        "path-parse": "^1.0.5",
+        "supports-color": "^3.1.2"
       },
       "dependencies": {
         "has-flag": {
@@ -2517,7 +3057,7 @@
           "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
           "dev": true,
           "requires": {
-            "has-flag": "1.0.0"
+            "has-flag": "^1.0.0"
           }
         }
       }
@@ -2528,11 +3068,11 @@
       "integrity": "sha512-8O2T/3VhrQHn0XcJbP1/GN7kXMiRAlPi+fj3uEHrjBD8Oz7Py0prSC25C09NuAZS6bgW1NNKAvCSHZXB0irSGA==",
       "dev": true,
       "requires": {
-        "debug": "3.1.0",
-        "istanbul-lib-coverage": "1.2.0",
-        "mkdirp": "0.5.1",
-        "rimraf": "2.6.2",
-        "source-map": "0.5.7"
+        "debug": "^3.1.0",
+        "istanbul-lib-coverage": "^1.2.0",
+        "mkdirp": "^0.5.1",
+        "rimraf": "^2.6.1",
+        "source-map": "^0.5.3"
       },
       "dependencies": {
         "debug": {
@@ -2552,7 +3092,7 @@
       "integrity": "sha512-y2Z2IMqE1gefWUaVjrBm0mSKvUkaBy9Vqz8iwr/r40Y9hBbIteH5wqHG/9DLTfJ9xUnUT2j7A3+VVJ6EaYBllA==",
       "dev": true,
       "requires": {
-        "handlebars": "4.0.11"
+        "handlebars": "^4.0.3"
       }
     },
     "isurl": {
@@ -2561,8 +3101,8 @@
       "integrity": "sha512-1P/yWsxPlDtn7QeRD+ULKQPaIaN6yF368GZ2vDfv0AL0NwpStafjWCDDdn0k8wgFMWpVAqG7oJhxHnlud42i9w==",
       "dev": true,
       "requires": {
-        "has-to-string-tag-x": "1.4.1",
-        "is-object": "1.0.1"
+        "has-to-string-tag-x": "^1.2.0",
+        "is-object": "^1.0.1"
       }
     },
     "jest": {
@@ -2571,8 +3111,8 @@
       "integrity": "sha1-u7f4kxAKEadC3YvQ0EelSwlorRo=",
       "dev": true,
       "requires": {
-        "import-local": "1.0.0",
-        "jest-cli": "23.1.0"
+        "import-local": "^1.0.0",
+        "jest-cli": "^23.1.0"
       },
       "dependencies": {
         "jest-cli": {
@@ -2581,41 +3121,41 @@
           "integrity": "sha1-64vdTODRUlCJLjGtm2m8mdKo9r8=",
           "dev": true,
           "requires": {
-            "ansi-escapes": "3.1.0",
-            "chalk": "2.4.1",
-            "exit": "0.1.2",
-            "glob": "7.1.2",
-            "graceful-fs": "4.1.11",
-            "import-local": "1.0.0",
-            "is-ci": "1.1.0",
-            "istanbul-api": "1.3.1",
-            "istanbul-lib-coverage": "1.2.0",
-            "istanbul-lib-instrument": "1.10.1",
-            "istanbul-lib-source-maps": "1.2.5",
-            "jest-changed-files": "23.0.1",
-            "jest-config": "23.1.0",
-            "jest-environment-jsdom": "23.1.0",
-            "jest-get-type": "22.4.3",
-            "jest-haste-map": "23.1.0",
-            "jest-message-util": "23.1.0",
-            "jest-regex-util": "23.0.0",
-            "jest-resolve-dependencies": "23.0.1",
-            "jest-runner": "23.1.0",
-            "jest-runtime": "23.1.0",
-            "jest-snapshot": "23.0.1",
-            "jest-util": "23.1.0",
-            "jest-validate": "23.0.1",
-            "jest-watcher": "23.1.0",
-            "jest-worker": "23.0.1",
-            "micromatch": "2.3.11",
-            "node-notifier": "5.2.1",
-            "realpath-native": "1.0.0",
-            "rimraf": "2.6.2",
-            "slash": "1.0.0",
-            "string-length": "2.0.0",
-            "strip-ansi": "4.0.0",
-            "which": "1.3.1",
-            "yargs": "11.0.0"
+            "ansi-escapes": "^3.0.0",
+            "chalk": "^2.0.1",
+            "exit": "^0.1.2",
+            "glob": "^7.1.2",
+            "graceful-fs": "^4.1.11",
+            "import-local": "^1.0.0",
+            "is-ci": "^1.0.10",
+            "istanbul-api": "^1.3.1",
+            "istanbul-lib-coverage": "^1.2.0",
+            "istanbul-lib-instrument": "^1.10.1",
+            "istanbul-lib-source-maps": "^1.2.4",
+            "jest-changed-files": "^23.0.1",
+            "jest-config": "^23.1.0",
+            "jest-environment-jsdom": "^23.1.0",
+            "jest-get-type": "^22.1.0",
+            "jest-haste-map": "^23.1.0",
+            "jest-message-util": "^23.1.0",
+            "jest-regex-util": "^23.0.0",
+            "jest-resolve-dependencies": "^23.0.1",
+            "jest-runner": "^23.1.0",
+            "jest-runtime": "^23.1.0",
+            "jest-snapshot": "^23.0.1",
+            "jest-util": "^23.1.0",
+            "jest-validate": "^23.0.1",
+            "jest-watcher": "^23.1.0",
+            "jest-worker": "^23.0.1",
+            "micromatch": "^2.3.11",
+            "node-notifier": "^5.2.1",
+            "realpath-native": "^1.0.0",
+            "rimraf": "^2.5.4",
+            "slash": "^1.0.0",
+            "string-length": "^2.0.0",
+            "strip-ansi": "^4.0.0",
+            "which": "^1.2.12",
+            "yargs": "^11.0.0"
           }
         }
       }
@@ -2626,7 +3166,7 @@
       "integrity": "sha1-95Vy0HIIROpd+EwqRI6GLCJU9gw=",
       "dev": true,
       "requires": {
-        "throat": "4.1.0"
+        "throat": "^4.0.0"
       }
     },
     "jest-config": {
@@ -2635,19 +3175,19 @@
       "integrity": "sha1-cIyg9DHTVu5CT7SJXTMIAGvdgkE=",
       "dev": true,
       "requires": {
-        "babel-core": "6.26.3",
-        "babel-jest": "23.0.1",
-        "chalk": "2.4.1",
-        "glob": "7.1.2",
-        "jest-environment-jsdom": "23.1.0",
-        "jest-environment-node": "23.1.0",
-        "jest-get-type": "22.4.3",
-        "jest-jasmine2": "23.1.0",
-        "jest-regex-util": "23.0.0",
-        "jest-resolve": "23.1.0",
-        "jest-util": "23.1.0",
-        "jest-validate": "23.0.1",
-        "pretty-format": "23.0.1"
+        "babel-core": "^6.0.0",
+        "babel-jest": "^23.0.1",
+        "chalk": "^2.0.1",
+        "glob": "^7.1.1",
+        "jest-environment-jsdom": "^23.1.0",
+        "jest-environment-node": "^23.1.0",
+        "jest-get-type": "^22.1.0",
+        "jest-jasmine2": "^23.1.0",
+        "jest-regex-util": "^23.0.0",
+        "jest-resolve": "^23.1.0",
+        "jest-util": "^23.1.0",
+        "jest-validate": "^23.0.1",
+        "pretty-format": "^23.0.1"
       }
     },
     "jest-diff": {
@@ -2656,10 +3196,10 @@
       "integrity": "sha1-PUkTfO4SwyCktNK0pvpugtSRoWo=",
       "dev": true,
       "requires": {
-        "chalk": "2.4.1",
-        "diff": "3.5.0",
-        "jest-get-type": "22.4.3",
-        "pretty-format": "23.0.1"
+        "chalk": "^2.0.1",
+        "diff": "^3.2.0",
+        "jest-get-type": "^22.1.0",
+        "pretty-format": "^23.0.1"
       }
     },
     "jest-docblock": {
@@ -2668,7 +3208,7 @@
       "integrity": "sha1-3t3RgzO+XcJBUmCgTvP86SdrVyU=",
       "dev": true,
       "requires": {
-        "detect-newline": "2.1.0"
+        "detect-newline": "^2.1.0"
       }
     },
     "jest-each": {
@@ -2677,8 +3217,8 @@
       "integrity": "sha1-FhRrWSw1SGelrl4TzfFcbGW2lsY=",
       "dev": true,
       "requires": {
-        "chalk": "2.4.1",
-        "pretty-format": "23.0.1"
+        "chalk": "^2.0.1",
+        "pretty-format": "^23.0.1"
       }
     },
     "jest-environment-jsdom": {
@@ -2687,9 +3227,9 @@
       "integrity": "sha1-hZKZFOI77TV32sl1X0EG0Gl8R5w=",
       "dev": true,
       "requires": {
-        "jest-mock": "23.1.0",
-        "jest-util": "23.1.0",
-        "jsdom": "11.11.0"
+        "jest-mock": "^23.1.0",
+        "jest-util": "^23.1.0",
+        "jsdom": "^11.5.1"
       }
     },
     "jest-environment-node": {
@@ -2698,8 +3238,8 @@
       "integrity": "sha1-RSwL+UnPy7rNoeF2Lu7XC8eEx9U=",
       "dev": true,
       "requires": {
-        "jest-mock": "23.1.0",
-        "jest-util": "23.1.0"
+        "jest-mock": "^23.1.0",
+        "jest-util": "^23.1.0"
       }
     },
     "jest-get-type": {
@@ -2714,13 +3254,13 @@
       "integrity": "sha1-GObH1ajScTb5G32YUvhd4McHTEk=",
       "dev": true,
       "requires": {
-        "fb-watchman": "2.0.0",
-        "graceful-fs": "4.1.11",
-        "jest-docblock": "23.0.1",
-        "jest-serializer": "23.0.1",
-        "jest-worker": "23.0.1",
-        "micromatch": "2.3.11",
-        "sane": "2.5.2"
+        "fb-watchman": "^2.0.0",
+        "graceful-fs": "^4.1.11",
+        "jest-docblock": "^23.0.1",
+        "jest-serializer": "^23.0.1",
+        "jest-worker": "^23.0.1",
+        "micromatch": "^2.3.11",
+        "sane": "^2.0.0"
       }
     },
     "jest-jasmine2": {
@@ -2729,17 +3269,17 @@
       "integrity": "sha1-SvqzFym2VN3NKwdK3YSTlvE7MLg=",
       "dev": true,
       "requires": {
-        "chalk": "2.4.1",
-        "co": "4.6.0",
-        "expect": "23.1.0",
-        "is-generator-fn": "1.0.0",
-        "jest-diff": "23.0.1",
-        "jest-each": "23.1.0",
-        "jest-matcher-utils": "23.0.1",
-        "jest-message-util": "23.1.0",
-        "jest-snapshot": "23.0.1",
-        "jest-util": "23.1.0",
-        "pretty-format": "23.0.1"
+        "chalk": "^2.0.1",
+        "co": "^4.6.0",
+        "expect": "^23.1.0",
+        "is-generator-fn": "^1.0.0",
+        "jest-diff": "^23.0.1",
+        "jest-each": "^23.1.0",
+        "jest-matcher-utils": "^23.0.1",
+        "jest-message-util": "^23.1.0",
+        "jest-snapshot": "^23.0.1",
+        "jest-util": "^23.1.0",
+        "pretty-format": "^23.0.1"
       }
     },
     "jest-leak-detector": {
@@ -2748,7 +3288,7 @@
       "integrity": "sha1-nboHUFrDSVw50+wJrB5WRZnoYaA=",
       "dev": true,
       "requires": {
-        "pretty-format": "23.0.1"
+        "pretty-format": "^23.0.1"
       }
     },
     "jest-matcher-utils": {
@@ -2757,9 +3297,9 @@
       "integrity": "sha1-DGwNrt+YM8Kn82I2Bp7+y0w/bl8=",
       "dev": true,
       "requires": {
-        "chalk": "2.4.1",
-        "jest-get-type": "22.4.3",
-        "pretty-format": "23.0.1"
+        "chalk": "^2.0.1",
+        "jest-get-type": "^22.1.0",
+        "pretty-format": "^23.0.1"
       }
     },
     "jest-message-util": {
@@ -2768,11 +3308,11 @@
       "integrity": "sha1-moCbpIfsrFzlEdTmmO47XuJGHqk=",
       "dev": true,
       "requires": {
-        "@babel/code-frame": "7.0.0-beta.51",
-        "chalk": "2.4.1",
-        "micromatch": "2.3.11",
-        "slash": "1.0.0",
-        "stack-utils": "1.0.1"
+        "@babel/code-frame": "^7.0.0-beta.35",
+        "chalk": "^2.0.1",
+        "micromatch": "^2.3.11",
+        "slash": "^1.0.0",
+        "stack-utils": "^1.0.1"
       }
     },
     "jest-mock": {
@@ -2793,9 +3333,9 @@
       "integrity": "sha1-ueMW7s69bwC8UKOWDRUnuuZXktI=",
       "dev": true,
       "requires": {
-        "browser-resolve": "1.11.3",
-        "chalk": "2.4.1",
-        "realpath-native": "1.0.0"
+        "browser-resolve": "^1.11.2",
+        "chalk": "^2.0.1",
+        "realpath-native": "^1.0.0"
       }
     },
     "jest-resolve-dependencies": {
@@ -2804,8 +3344,8 @@
       "integrity": "sha1-0BoQ3a2RUsTOzfXqwriFccS2pk0=",
       "dev": true,
       "requires": {
-        "jest-regex-util": "23.0.0",
-        "jest-snapshot": "23.0.1"
+        "jest-regex-util": "^23.0.0",
+        "jest-snapshot": "^23.0.1"
       }
     },
     "jest-runner": {
@@ -2814,19 +3354,19 @@
       "integrity": "sha1-+iCpM//3MaVDKzVh5/ZCZZT6KbU=",
       "dev": true,
       "requires": {
-        "exit": "0.1.2",
-        "graceful-fs": "4.1.11",
-        "jest-config": "23.1.0",
-        "jest-docblock": "23.0.1",
-        "jest-haste-map": "23.1.0",
-        "jest-jasmine2": "23.1.0",
-        "jest-leak-detector": "23.0.1",
-        "jest-message-util": "23.1.0",
-        "jest-runtime": "23.1.0",
-        "jest-util": "23.1.0",
-        "jest-worker": "23.0.1",
-        "source-map-support": "0.5.6",
-        "throat": "4.1.0"
+        "exit": "^0.1.2",
+        "graceful-fs": "^4.1.11",
+        "jest-config": "^23.1.0",
+        "jest-docblock": "^23.0.1",
+        "jest-haste-map": "^23.1.0",
+        "jest-jasmine2": "^23.1.0",
+        "jest-leak-detector": "^23.0.1",
+        "jest-message-util": "^23.1.0",
+        "jest-runtime": "^23.1.0",
+        "jest-util": "^23.1.0",
+        "jest-worker": "^23.0.1",
+        "source-map-support": "^0.5.6",
+        "throat": "^4.0.0"
       },
       "dependencies": {
         "source-map": {
@@ -2841,8 +3381,8 @@
           "integrity": "sha512-N4KXEz7jcKqPf2b2vZF11lQIz9W5ZMuUcIOGj243lduidkf2fjkVKJS9vNxVWn3u/uxX38AcE8U9nnH9FPcq+g==",
           "dev": true,
           "requires": {
-            "buffer-from": "1.1.0",
-            "source-map": "0.6.1"
+            "buffer-from": "^1.0.0",
+            "source-map": "^0.6.0"
           }
         }
       }
@@ -2853,27 +3393,27 @@
       "integrity": "sha1-tK4OhyWeys/UqIS2OdsHz03WIK8=",
       "dev": true,
       "requires": {
-        "babel-core": "6.26.3",
-        "babel-plugin-istanbul": "4.1.6",
-        "chalk": "2.4.1",
-        "convert-source-map": "1.5.1",
-        "exit": "0.1.2",
-        "fast-json-stable-stringify": "2.0.0",
-        "graceful-fs": "4.1.11",
-        "jest-config": "23.1.0",
-        "jest-haste-map": "23.1.0",
-        "jest-message-util": "23.1.0",
-        "jest-regex-util": "23.0.0",
-        "jest-resolve": "23.1.0",
-        "jest-snapshot": "23.0.1",
-        "jest-util": "23.1.0",
-        "jest-validate": "23.0.1",
-        "micromatch": "2.3.11",
-        "realpath-native": "1.0.0",
-        "slash": "1.0.0",
+        "babel-core": "^6.0.0",
+        "babel-plugin-istanbul": "^4.1.6",
+        "chalk": "^2.0.1",
+        "convert-source-map": "^1.4.0",
+        "exit": "^0.1.2",
+        "fast-json-stable-stringify": "^2.0.0",
+        "graceful-fs": "^4.1.11",
+        "jest-config": "^23.1.0",
+        "jest-haste-map": "^23.1.0",
+        "jest-message-util": "^23.1.0",
+        "jest-regex-util": "^23.0.0",
+        "jest-resolve": "^23.1.0",
+        "jest-snapshot": "^23.0.1",
+        "jest-util": "^23.1.0",
+        "jest-validate": "^23.0.1",
+        "micromatch": "^2.3.11",
+        "realpath-native": "^1.0.0",
+        "slash": "^1.0.0",
         "strip-bom": "3.0.0",
-        "write-file-atomic": "2.3.0",
-        "yargs": "11.0.0"
+        "write-file-atomic": "^2.1.0",
+        "yargs": "^11.0.0"
       }
     },
     "jest-serializer": {
@@ -2888,12 +3428,12 @@
       "integrity": "sha1-ZnT6Gbnraamcq+zUFb3cQtavPn4=",
       "dev": true,
       "requires": {
-        "chalk": "2.4.1",
-        "jest-diff": "23.0.1",
-        "jest-matcher-utils": "23.0.1",
-        "mkdirp": "0.5.1",
-        "natural-compare": "1.4.0",
-        "pretty-format": "23.0.1"
+        "chalk": "^2.0.1",
+        "jest-diff": "^23.0.1",
+        "jest-matcher-utils": "^23.0.1",
+        "mkdirp": "^0.5.1",
+        "natural-compare": "^1.4.0",
+        "pretty-format": "^23.0.1"
       }
     },
     "jest-util": {
@@ -2902,14 +3442,14 @@
       "integrity": "sha1-wCUbrzRkTG3S/qeKli9CY6xVdy0=",
       "dev": true,
       "requires": {
-        "callsites": "2.0.0",
-        "chalk": "2.4.1",
-        "graceful-fs": "4.1.11",
-        "is-ci": "1.1.0",
-        "jest-message-util": "23.1.0",
-        "mkdirp": "0.5.1",
-        "slash": "1.0.0",
-        "source-map": "0.6.1"
+        "callsites": "^2.0.0",
+        "chalk": "^2.0.1",
+        "graceful-fs": "^4.1.11",
+        "is-ci": "^1.0.10",
+        "jest-message-util": "^23.1.0",
+        "mkdirp": "^0.5.1",
+        "slash": "^1.0.0",
+        "source-map": "^0.6.0"
       },
       "dependencies": {
         "source-map": {
@@ -2926,10 +3466,10 @@
       "integrity": "sha1-zZ8BqJ0mu4hfEqhmdxXpyGWldU8=",
       "dev": true,
       "requires": {
-        "chalk": "2.4.1",
-        "jest-get-type": "22.4.3",
-        "leven": "2.1.0",
-        "pretty-format": "23.0.1"
+        "chalk": "^2.0.1",
+        "jest-get-type": "^22.1.0",
+        "leven": "^2.1.0",
+        "pretty-format": "^23.0.1"
       }
     },
     "jest-watcher": {
@@ -2938,9 +3478,9 @@
       "integrity": "sha1-qNWELjjZ+0r/+CPfartCpYrmzb0=",
       "dev": true,
       "requires": {
-        "ansi-escapes": "3.1.0",
-        "chalk": "2.4.1",
-        "string-length": "2.0.0"
+        "ansi-escapes": "^3.0.0",
+        "chalk": "^2.0.1",
+        "string-length": "^2.0.0"
       }
     },
     "jest-worker": {
@@ -2949,7 +3489,7 @@
       "integrity": "sha1-nmSd2WP/QEYCb5HEAX8Dmmqkp7w=",
       "dev": true,
       "requires": {
-        "merge-stream": "1.0.1"
+        "merge-stream": "^1.0.1"
       }
     },
     "js-tokens": {
@@ -2964,8 +3504,8 @@
       "integrity": "sha512-PIt2cnwmPfL4hKNwqeiuz4bKfnzHTBv6HyVgjahA6mPLwPDzjDWrplJBMjHUFxku/N3FlmrbyPclad+I+4mJ3A==",
       "dev": true,
       "requires": {
-        "argparse": "1.0.10",
-        "esprima": "4.0.0"
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
       }
     },
     "jsbn": {
@@ -2981,32 +3521,32 @@
       "integrity": "sha512-ou1VyfjwsSuWkudGxb03FotDajxAto6USAlmMZjE2lc0jCznt7sBWkhfRBRaWwbnmDqdMSTKTLT5d9sBFkkM7A==",
       "dev": true,
       "requires": {
-        "abab": "1.0.4",
-        "acorn": "5.7.1",
-        "acorn-globals": "4.1.0",
-        "array-equal": "1.0.0",
-        "cssom": "0.3.2",
-        "cssstyle": "0.3.1",
-        "data-urls": "1.0.0",
-        "domexception": "1.0.1",
-        "escodegen": "1.10.0",
-        "html-encoding-sniffer": "1.0.2",
-        "left-pad": "1.3.0",
-        "nwsapi": "2.0.4",
+        "abab": "^1.0.4",
+        "acorn": "^5.3.0",
+        "acorn-globals": "^4.1.0",
+        "array-equal": "^1.0.0",
+        "cssom": ">= 0.3.2 < 0.4.0",
+        "cssstyle": ">= 0.3.1 < 0.4.0",
+        "data-urls": "^1.0.0",
+        "domexception": "^1.0.0",
+        "escodegen": "^1.9.0",
+        "html-encoding-sniffer": "^1.0.2",
+        "left-pad": "^1.2.0",
+        "nwsapi": "^2.0.0",
         "parse5": "4.0.0",
-        "pn": "1.1.0",
-        "request": "2.87.0",
-        "request-promise-native": "1.0.5",
-        "sax": "1.2.4",
-        "symbol-tree": "3.2.2",
-        "tough-cookie": "2.4.2",
-        "w3c-hr-time": "1.0.1",
-        "webidl-conversions": "4.0.2",
-        "whatwg-encoding": "1.0.3",
-        "whatwg-mimetype": "2.1.0",
-        "whatwg-url": "6.5.0",
-        "ws": "4.1.0",
-        "xml-name-validator": "3.0.0"
+        "pn": "^1.1.0",
+        "request": "^2.83.0",
+        "request-promise-native": "^1.0.5",
+        "sax": "^1.2.4",
+        "symbol-tree": "^3.2.2",
+        "tough-cookie": "^2.3.3",
+        "w3c-hr-time": "^1.0.1",
+        "webidl-conversions": "^4.0.2",
+        "whatwg-encoding": "^1.0.3",
+        "whatwg-mimetype": "^2.1.0",
+        "whatwg-url": "^6.4.1",
+        "ws": "^4.0.0",
+        "xml-name-validator": "^3.0.0"
       }
     },
     "jsesc": {
@@ -3045,6 +3585,15 @@
       "integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE=",
       "dev": true
     },
+    "jsonfile": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+      "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
     "jsprim": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
@@ -3072,7 +3621,7 @@
       "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
       "dev": true,
       "requires": {
-        "is-buffer": "1.1.6"
+        "is-buffer": "^1.1.5"
       }
     },
     "lazy-cache": {
@@ -3088,7 +3637,7 @@
       "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
       "dev": true,
       "requires": {
-        "invert-kv": "1.0.0"
+        "invert-kv": "^1.0.0"
       }
     },
     "left-pad": {
@@ -3109,8 +3658,8 @@
       "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
       "dev": true,
       "requires": {
-        "prelude-ls": "1.1.2",
-        "type-check": "0.3.2"
+        "prelude-ls": "~1.1.2",
+        "type-check": "~0.3.2"
       }
     },
     "load-json-file": {
@@ -3119,11 +3668,11 @@
       "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
       "dev": true,
       "requires": {
-        "graceful-fs": "4.1.11",
-        "parse-json": "2.2.0",
-        "pify": "2.3.0",
-        "pinkie-promise": "2.0.1",
-        "strip-bom": "2.0.0"
+        "graceful-fs": "^4.1.2",
+        "parse-json": "^2.2.0",
+        "pify": "^2.0.0",
+        "pinkie-promise": "^2.0.0",
+        "strip-bom": "^2.0.0"
       },
       "dependencies": {
         "pify": {
@@ -3138,7 +3687,7 @@
           "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
           "dev": true,
           "requires": {
-            "is-utf8": "0.2.1"
+            "is-utf8": "^0.2.0"
           }
         }
       }
@@ -3149,8 +3698,8 @@
       "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
       "dev": true,
       "requires": {
-        "p-locate": "2.0.0",
-        "path-exists": "3.0.0"
+        "p-locate": "^2.0.0",
+        "path-exists": "^3.0.0"
       }
     },
     "lodash": {
@@ -3177,7 +3726,7 @@
       "integrity": "sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg=",
       "dev": true,
       "requires": {
-        "js-tokens": "3.0.2"
+        "js-tokens": "^3.0.0"
       }
     },
     "lowercase-keys": {
@@ -3192,8 +3741,8 @@
       "integrity": "sha512-fFEhvcgzuIoJVUF8fYr5KR0YqxD238zgObTps31YdADwPPAp82a4M8TrckkWyx7ekNlf9aBcVn81cFwwXngrJA==",
       "dev": true,
       "requires": {
-        "pseudomap": "1.0.2",
-        "yallist": "2.1.2"
+        "pseudomap": "^1.0.2",
+        "yallist": "^2.1.2"
       }
     },
     "make-dir": {
@@ -3202,7 +3751,7 @@
       "integrity": "sha512-2w31R7SJtieJJnQtGc7RVL2StM2vGYVfqUOvUDxH6bC6aJTxPxTF0GnIgCyu7tjockiUWAYQRbxa7vKn34s5sQ==",
       "dev": true,
       "requires": {
-        "pify": "3.0.0"
+        "pify": "^3.0.0"
       }
     },
     "makeerror": {
@@ -3211,7 +3760,7 @@
       "integrity": "sha1-4BpckQnyr3lmDk6LlYd5AYT1qWw=",
       "dev": true,
       "requires": {
-        "tmpl": "1.0.4"
+        "tmpl": "1.0.x"
       }
     },
     "map-cache": {
@@ -3226,7 +3775,7 @@
       "integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
       "dev": true,
       "requires": {
-        "object-visit": "1.0.1"
+        "object-visit": "^1.0.0"
       }
     },
     "math-random": {
@@ -3241,7 +3790,7 @@
       "integrity": "sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=",
       "dev": true,
       "requires": {
-        "mimic-fn": "1.2.0"
+        "mimic-fn": "^1.0.0"
       }
     },
     "merge": {
@@ -3256,7 +3805,7 @@
       "integrity": "sha1-QEEgLVCKNCugAXQAjfDCUbjBNeE=",
       "dev": true,
       "requires": {
-        "readable-stream": "2.3.6"
+        "readable-stream": "^2.0.1"
       }
     },
     "micromatch": {
@@ -3265,19 +3814,19 @@
       "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
       "dev": true,
       "requires": {
-        "arr-diff": "2.0.0",
-        "array-unique": "0.2.1",
-        "braces": "1.8.5",
-        "expand-brackets": "0.1.5",
-        "extglob": "0.3.2",
-        "filename-regex": "2.0.1",
-        "is-extglob": "1.0.0",
-        "is-glob": "2.0.1",
-        "kind-of": "3.2.2",
-        "normalize-path": "2.1.1",
-        "object.omit": "2.0.1",
-        "parse-glob": "3.0.4",
-        "regex-cache": "0.4.4"
+        "arr-diff": "^2.0.0",
+        "array-unique": "^0.2.1",
+        "braces": "^1.8.2",
+        "expand-brackets": "^0.1.4",
+        "extglob": "^0.3.1",
+        "filename-regex": "^2.0.0",
+        "is-extglob": "^1.0.0",
+        "is-glob": "^2.0.1",
+        "kind-of": "^3.0.2",
+        "normalize-path": "^2.0.1",
+        "object.omit": "^2.0.0",
+        "parse-glob": "^3.0.4",
+        "regex-cache": "^0.4.2"
       },
       "dependencies": {
         "arr-diff": {
@@ -3286,7 +3835,7 @@
           "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
           "dev": true,
           "requires": {
-            "arr-flatten": "1.1.0"
+            "arr-flatten": "^1.0.1"
           }
         },
         "array-unique": {
@@ -3301,9 +3850,9 @@
           "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
           "dev": true,
           "requires": {
-            "expand-range": "1.8.2",
-            "preserve": "0.2.0",
-            "repeat-element": "1.1.2"
+            "expand-range": "^1.8.1",
+            "preserve": "^0.2.0",
+            "repeat-element": "^1.1.2"
           }
         },
         "expand-brackets": {
@@ -3312,7 +3861,7 @@
           "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
           "dev": true,
           "requires": {
-            "is-posix-bracket": "0.1.1"
+            "is-posix-bracket": "^0.1.0"
           }
         },
         "extglob": {
@@ -3321,7 +3870,7 @@
           "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
           "dev": true,
           "requires": {
-            "is-extglob": "1.0.0"
+            "is-extglob": "^1.0.0"
           }
         }
       }
@@ -3338,7 +3887,7 @@
       "integrity": "sha512-lc/aahn+t4/SWV/qcmumYjymLsWfN3ELhpmVuUFjgsORruuZPVSwAQryq+HHGvO/SI2KVX26bx+En+zhM8g8hQ==",
       "dev": true,
       "requires": {
-        "mime-db": "1.33.0"
+        "mime-db": "~1.33.0"
       },
       "dependencies": {
         "mime-db": {
@@ -3367,7 +3916,7 @@
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
       "dev": true,
       "requires": {
-        "brace-expansion": "1.1.11"
+        "brace-expansion": "^1.1.7"
       }
     },
     "minimist": {
@@ -3382,8 +3931,8 @@
       "integrity": "sha512-8ZItLHeEgaqEvd5lYBXfm4EZSFCX29Jb9K+lAHhDKzReKBQKj3R+7NOF6tjqYi9t4oI8VUfaWITJQm86wnXGNQ==",
       "dev": true,
       "requires": {
-        "for-in": "1.0.2",
-        "is-extendable": "1.0.1"
+        "for-in": "^1.0.2",
+        "is-extendable": "^1.0.1"
       },
       "dependencies": {
         "is-extendable": {
@@ -3392,7 +3941,7 @@
           "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
           "dev": true,
           "requires": {
-            "is-plain-object": "2.0.4"
+            "is-plain-object": "^2.0.4"
           }
         }
       }
@@ -3412,24 +3961,31 @@
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
       "dev": true
     },
+    "nan": {
+      "version": "2.11.1",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.11.1.tgz",
+      "integrity": "sha512-iji6k87OSXa0CcrLl9z+ZiYSuR2o+c0bGuNmXdrhTQTakxytAFsC56SArGYoiHlJlFoHSnvmhpceZJaXkVuOtA==",
+      "dev": true,
+      "optional": true
+    },
     "nanomatch": {
       "version": "1.2.9",
       "resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.9.tgz",
       "integrity": "sha512-n8R9bS8yQ6eSXaV6jHUpKzD8gLsin02w1HSFiegwrs9E098Ylhw5jdyKPaYqvHknHaSCKTPp7C8dGCQ0q9koXA==",
       "dev": true,
       "requires": {
-        "arr-diff": "4.0.0",
-        "array-unique": "0.3.2",
-        "define-property": "2.0.2",
-        "extend-shallow": "3.0.2",
-        "fragment-cache": "0.2.1",
-        "is-odd": "2.0.0",
-        "is-windows": "1.0.2",
-        "kind-of": "6.0.2",
-        "object.pick": "1.3.0",
-        "regex-not": "1.0.2",
-        "snapdragon": "0.8.2",
-        "to-regex": "3.0.2"
+        "arr-diff": "^4.0.0",
+        "array-unique": "^0.3.2",
+        "define-property": "^2.0.2",
+        "extend-shallow": "^3.0.2",
+        "fragment-cache": "^0.2.1",
+        "is-odd": "^2.0.0",
+        "is-windows": "^1.0.2",
+        "kind-of": "^6.0.2",
+        "object.pick": "^1.3.0",
+        "regex-not": "^1.0.0",
+        "snapdragon": "^0.8.1",
+        "to-regex": "^3.0.1"
       },
       "dependencies": {
         "kind-of": {
@@ -3458,10 +4014,10 @@
       "integrity": "sha512-MIBs+AAd6dJ2SklbbE8RUDRlIVhU8MaNLh1A9SUZDUHPiZkWLFde6UNwG41yQHZEToHgJMXqyVZ9UcS/ReOVTg==",
       "dev": true,
       "requires": {
-        "growly": "1.3.0",
-        "semver": "5.5.0",
-        "shellwords": "0.1.1",
-        "which": "1.3.1"
+        "growly": "^1.3.0",
+        "semver": "^5.4.1",
+        "shellwords": "^0.1.1",
+        "which": "^1.3.0"
       }
     },
     "normalize-package-data": {
@@ -3470,10 +4026,10 @@
       "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
       "dev": true,
       "requires": {
-        "hosted-git-info": "2.6.0",
-        "is-builtin-module": "1.0.0",
-        "semver": "5.5.0",
-        "validate-npm-package-license": "3.0.3"
+        "hosted-git-info": "^2.1.4",
+        "is-builtin-module": "^1.0.0",
+        "semver": "2 || 3 || 4 || 5",
+        "validate-npm-package-license": "^3.0.1"
       }
     },
     "normalize-path": {
@@ -3482,7 +4038,7 @@
       "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
       "dev": true,
       "requires": {
-        "remove-trailing-separator": "1.1.0"
+        "remove-trailing-separator": "^1.0.1"
       }
     },
     "normalize-url": {
@@ -3491,9 +4047,9 @@
       "integrity": "sha512-D6MUW4K/VzoJ4rJ01JFKxDrtY1v9wrgzCX5f2qj/lzH1m/lW6MhUZFKerVsnyjOhOsYzI9Kqqak+10l4LvLpMw==",
       "dev": true,
       "requires": {
-        "prepend-http": "2.0.0",
-        "query-string": "5.1.1",
-        "sort-keys": "2.0.0"
+        "prepend-http": "^2.0.0",
+        "query-string": "^5.0.1",
+        "sort-keys": "^2.0.0"
       },
       "dependencies": {
         "sort-keys": {
@@ -3502,7 +4058,7 @@
           "integrity": "sha1-ZYU1WEhh7JfXMNbPQYIuH1ZoQSg=",
           "dev": true,
           "requires": {
-            "is-plain-obj": "1.1.0"
+            "is-plain-obj": "^1.0.0"
           }
         }
       }
@@ -3513,8 +4069,8 @@
       "integrity": "sha512-Yic4bZHJOt9RCFbRP3GgpqhScOY4HH3V2P8yBj6CeYq118Qr+BLXqT2JvpJ00mryLESpgOxf5XlFv4ZjXxLScw==",
       "dev": true,
       "requires": {
-        "config-chain": "1.1.11",
-        "pify": "3.0.0"
+        "config-chain": "^1.1.11",
+        "pify": "^3.0.0"
       }
     },
     "npm-run-path": {
@@ -3523,7 +4079,7 @@
       "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
       "dev": true,
       "requires": {
-        "path-key": "2.0.1"
+        "path-key": "^2.0.0"
       }
     },
     "number-is-nan": {
@@ -3556,9 +4112,9 @@
       "integrity": "sha1-fn2Fi3gb18mRpBupde04EnVOmYw=",
       "dev": true,
       "requires": {
-        "copy-descriptor": "0.1.1",
-        "define-property": "0.2.5",
-        "kind-of": "3.2.2"
+        "copy-descriptor": "^0.1.0",
+        "define-property": "^0.2.5",
+        "kind-of": "^3.0.3"
       },
       "dependencies": {
         "define-property": {
@@ -3567,7 +4123,7 @@
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "dev": true,
           "requires": {
-            "is-descriptor": "0.1.6"
+            "is-descriptor": "^0.1.0"
           }
         }
       }
@@ -3584,7 +4140,7 @@
       "integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
       "dev": true,
       "requires": {
-        "isobject": "3.0.1"
+        "isobject": "^3.0.0"
       }
     },
     "object.getownpropertydescriptors": {
@@ -3593,8 +4149,8 @@
       "integrity": "sha1-h1jIRvW0B62rDyNuCYbxSwUcqhY=",
       "dev": true,
       "requires": {
-        "define-properties": "1.1.2",
-        "es-abstract": "1.12.0"
+        "define-properties": "^1.1.2",
+        "es-abstract": "^1.5.1"
       }
     },
     "object.omit": {
@@ -3603,8 +4159,8 @@
       "integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
       "dev": true,
       "requires": {
-        "for-own": "0.1.5",
-        "is-extendable": "0.1.1"
+        "for-own": "^0.1.4",
+        "is-extendable": "^0.1.1"
       }
     },
     "object.pick": {
@@ -3613,7 +4169,7 @@
       "integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
       "dev": true,
       "requires": {
-        "isobject": "3.0.1"
+        "isobject": "^3.0.1"
       }
     },
     "once": {
@@ -3622,7 +4178,7 @@
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
       "dev": true,
       "requires": {
-        "wrappy": "1.0.2"
+        "wrappy": "1"
       }
     },
     "optimist": {
@@ -3631,8 +4187,8 @@
       "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
       "dev": true,
       "requires": {
-        "minimist": "0.0.8",
-        "wordwrap": "0.0.3"
+        "minimist": "~0.0.1",
+        "wordwrap": "~0.0.2"
       }
     },
     "optionator": {
@@ -3641,12 +4197,12 @@
       "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
       "dev": true,
       "requires": {
-        "deep-is": "0.1.3",
-        "fast-levenshtein": "2.0.6",
-        "levn": "0.3.0",
-        "prelude-ls": "1.1.2",
-        "type-check": "0.3.2",
-        "wordwrap": "1.0.0"
+        "deep-is": "~0.1.3",
+        "fast-levenshtein": "~2.0.4",
+        "levn": "~0.3.0",
+        "prelude-ls": "~1.1.2",
+        "type-check": "~0.3.2",
+        "wordwrap": "~1.0.0"
       },
       "dependencies": {
         "wordwrap": {
@@ -3669,9 +4225,9 @@
       "integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
       "dev": true,
       "requires": {
-        "execa": "0.7.0",
-        "lcid": "1.0.0",
-        "mem": "1.1.0"
+        "execa": "^0.7.0",
+        "lcid": "^1.0.0",
+        "mem": "^1.1.0"
       }
     },
     "os-tmpdir": {
@@ -3692,7 +4248,7 @@
       "integrity": "sha1-jmtPT2XHK8W2/ii3XtqHT5akoIU=",
       "dev": true,
       "requires": {
-        "p-timeout": "1.2.1"
+        "p-timeout": "^1.1.1"
       },
       "dependencies": {
         "p-timeout": {
@@ -3701,7 +4257,7 @@
           "integrity": "sha1-XrOzU7f86Z8QGhA4iAuwVOu+o4Y=",
           "dev": true,
           "requires": {
-            "p-finally": "1.0.0"
+            "p-finally": "^1.0.0"
           }
         }
       }
@@ -3724,7 +4280,7 @@
       "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
       "dev": true,
       "requires": {
-        "p-try": "1.0.0"
+        "p-try": "^1.0.0"
       }
     },
     "p-locate": {
@@ -3733,7 +4289,7 @@
       "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
       "dev": true,
       "requires": {
-        "p-limit": "1.3.0"
+        "p-limit": "^1.1.0"
       }
     },
     "p-timeout": {
@@ -3742,7 +4298,7 @@
       "integrity": "sha512-88em58dDVB/KzPEx1X0N3LwFfYZPyDc4B6eF38M1rk9VTZMbxXXgjugz8mmwpS9Ox4BDZ+t6t3QP5+/gazweIA==",
       "dev": true,
       "requires": {
-        "p-finally": "1.0.0"
+        "p-finally": "^1.0.0"
       }
     },
     "p-try": {
@@ -3757,10 +4313,10 @@
       "integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
       "dev": true,
       "requires": {
-        "glob-base": "0.3.0",
-        "is-dotfile": "1.0.3",
-        "is-extglob": "1.0.0",
-        "is-glob": "2.0.1"
+        "glob-base": "^0.3.0",
+        "is-dotfile": "^1.0.0",
+        "is-extglob": "^1.0.0",
+        "is-glob": "^2.0.0"
       }
     },
     "parse-json": {
@@ -3769,7 +4325,7 @@
       "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
       "dev": true,
       "requires": {
-        "error-ex": "1.3.2"
+        "error-ex": "^1.2.0"
       }
     },
     "parse5": {
@@ -3814,9 +4370,9 @@
       "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
       "dev": true,
       "requires": {
-        "graceful-fs": "4.1.11",
-        "pify": "2.3.0",
-        "pinkie-promise": "2.0.1"
+        "graceful-fs": "^4.1.2",
+        "pify": "^2.0.0",
+        "pinkie-promise": "^2.0.0"
       },
       "dependencies": {
         "pify": {
@@ -3857,7 +4413,7 @@
       "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
       "dev": true,
       "requires": {
-        "pinkie": "2.0.4"
+        "pinkie": "^2.0.0"
       }
     },
     "pkg-dir": {
@@ -3866,7 +4422,7 @@
       "integrity": "sha1-9tXREJ4Z1j7fQo4L1X4Sd3YVM0s=",
       "dev": true,
       "requires": {
-        "find-up": "2.1.0"
+        "find-up": "^2.1.0"
       }
     },
     "pn": {
@@ -3905,8 +4461,8 @@
       "integrity": "sha1-1h0GUmjkx1kIO8y8onoBrXx2AfQ=",
       "dev": true,
       "requires": {
-        "ansi-regex": "3.0.0",
-        "ansi-styles": "3.2.1"
+        "ansi-regex": "^3.0.0",
+        "ansi-styles": "^3.2.0"
       },
       "dependencies": {
         "ansi-regex": {
@@ -3965,9 +4521,9 @@
       "integrity": "sha512-gjWOsm2SoGlgLEdAGt7a6slVOk9mGiXmPFMqrEhLQ68rhQuBnpfs3+EmlvqKyxnCo9/PPlF+9MtY02S1aFg+Jw==",
       "dev": true,
       "requires": {
-        "decode-uri-component": "0.2.0",
-        "object-assign": "4.1.1",
-        "strict-uri-encode": "1.1.0"
+        "decode-uri-component": "^0.2.0",
+        "object-assign": "^4.1.0",
+        "strict-uri-encode": "^1.0.0"
       }
     },
     "randomatic": {
@@ -3976,9 +4532,9 @@
       "integrity": "sha512-VdxFOIEY3mNO5PtSRkkle/hPJDHvQhK21oa73K4yAc9qmp6N429gAyF1gZMOTMeS0/AYzaV/2Trcef+NaIonSA==",
       "dev": true,
       "requires": {
-        "is-number": "4.0.0",
-        "kind-of": "6.0.2",
-        "math-random": "1.0.1"
+        "is-number": "^4.0.0",
+        "kind-of": "^6.0.0",
+        "math-random": "^1.0.1"
       },
       "dependencies": {
         "is-number": {
@@ -4001,9 +4557,9 @@
       "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
       "dev": true,
       "requires": {
-        "load-json-file": "1.1.0",
-        "normalize-package-data": "2.4.0",
-        "path-type": "1.1.0"
+        "load-json-file": "^1.0.0",
+        "normalize-package-data": "^2.3.2",
+        "path-type": "^1.0.0"
       }
     },
     "read-pkg-up": {
@@ -4012,8 +4568,8 @@
       "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
       "dev": true,
       "requires": {
-        "find-up": "1.1.2",
-        "read-pkg": "1.1.0"
+        "find-up": "^1.0.0",
+        "read-pkg": "^1.0.0"
       },
       "dependencies": {
         "find-up": {
@@ -4022,8 +4578,8 @@
           "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
           "dev": true,
           "requires": {
-            "path-exists": "2.1.0",
-            "pinkie-promise": "2.0.1"
+            "path-exists": "^2.0.0",
+            "pinkie-promise": "^2.0.0"
           }
         },
         "path-exists": {
@@ -4032,7 +4588,7 @@
           "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
           "dev": true,
           "requires": {
-            "pinkie-promise": "2.0.1"
+            "pinkie-promise": "^2.0.0"
           }
         }
       }
@@ -4043,13 +4599,13 @@
       "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
       "dev": true,
       "requires": {
-        "core-util-is": "1.0.2",
-        "inherits": "2.0.3",
-        "isarray": "1.0.0",
-        "process-nextick-args": "2.0.0",
-        "safe-buffer": "5.1.2",
-        "string_decoder": "1.1.1",
-        "util-deprecate": "1.0.2"
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
       }
     },
     "realpath-native": {
@@ -4058,7 +4614,7 @@
       "integrity": "sha512-XJtlRJ9jf0E1H1SLeJyQ9PGzQD7S65h1pRXEcAeK48doKOnKxcgPeNohJvD5u/2sI9J1oke6E8bZHS/fmW1UiQ==",
       "dev": true,
       "requires": {
-        "util.promisify": "1.0.0"
+        "util.promisify": "^1.0.0"
       }
     },
     "regenerator-runtime": {
@@ -4073,7 +4629,7 @@
       "integrity": "sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==",
       "dev": true,
       "requires": {
-        "is-equal-shallow": "0.1.3"
+        "is-equal-shallow": "^0.1.3"
       }
     },
     "regex-not": {
@@ -4082,8 +4638,8 @@
       "integrity": "sha512-J6SDjUgDxQj5NusnOtdFxDwN/+HWykR8GELwctJ7mdqhcyy1xEc4SRFHUXvxTp661YaVKAjfRLZ9cCqS6tn32A==",
       "dev": true,
       "requires": {
-        "extend-shallow": "3.0.2",
-        "safe-regex": "1.1.0"
+        "extend-shallow": "^3.0.2",
+        "safe-regex": "^1.1.0"
       }
     },
     "remove-trailing-separator": {
@@ -4110,7 +4666,7 @@
       "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
       "dev": true,
       "requires": {
-        "is-finite": "1.0.2"
+        "is-finite": "^1.0.0"
       }
     },
     "request": {
@@ -4119,26 +4675,26 @@
       "integrity": "sha512-fcogkm7Az5bsS6Sl0sibkbhcKsnyon/jV1kF3ajGmF0c8HrttdKTPRT9hieOaQHA5HEq6r8OyWOo/o781C1tNw==",
       "dev": true,
       "requires": {
-        "aws-sign2": "0.7.0",
-        "aws4": "1.7.0",
-        "caseless": "0.12.0",
-        "combined-stream": "1.0.6",
-        "extend": "3.0.1",
-        "forever-agent": "0.6.1",
-        "form-data": "2.3.2",
-        "har-validator": "5.0.3",
-        "http-signature": "1.2.0",
-        "is-typedarray": "1.0.0",
-        "isstream": "0.1.2",
-        "json-stringify-safe": "5.0.1",
-        "mime-types": "2.1.18",
-        "oauth-sign": "0.8.2",
-        "performance-now": "2.1.0",
-        "qs": "6.5.2",
-        "safe-buffer": "5.1.2",
-        "tough-cookie": "2.3.4",
-        "tunnel-agent": "0.6.0",
-        "uuid": "3.2.1"
+        "aws-sign2": "~0.7.0",
+        "aws4": "^1.6.0",
+        "caseless": "~0.12.0",
+        "combined-stream": "~1.0.5",
+        "extend": "~3.0.1",
+        "forever-agent": "~0.6.1",
+        "form-data": "~2.3.1",
+        "har-validator": "~5.0.3",
+        "http-signature": "~1.2.0",
+        "is-typedarray": "~1.0.0",
+        "isstream": "~0.1.2",
+        "json-stringify-safe": "~5.0.1",
+        "mime-types": "~2.1.17",
+        "oauth-sign": "~0.8.2",
+        "performance-now": "^2.1.0",
+        "qs": "~6.5.1",
+        "safe-buffer": "^5.1.1",
+        "tough-cookie": "~2.3.3",
+        "tunnel-agent": "^0.6.0",
+        "uuid": "^3.1.0"
       },
       "dependencies": {
         "punycode": {
@@ -4153,7 +4709,7 @@
           "integrity": "sha512-TZ6TTfI5NtZnuyy/Kecv+CnoROnyXn2DN97LontgQpCwsX2XyLYCC0ENhYkehSOwAp8rTQKc/NUIF7BkQ5rKLA==",
           "dev": true,
           "requires": {
-            "punycode": "1.4.1"
+            "punycode": "^1.4.1"
           }
         }
       }
@@ -4164,7 +4720,7 @@
       "integrity": "sha1-Pu4AssWqgyOc+wTFcA2jb4HNCLY=",
       "dev": true,
       "requires": {
-        "lodash": "4.17.10"
+        "lodash": "^4.13.1"
       }
     },
     "request-promise-native": {
@@ -4174,8 +4730,8 @@
       "dev": true,
       "requires": {
         "request-promise-core": "1.1.1",
-        "stealthy-require": "1.1.1",
-        "tough-cookie": "2.4.2"
+        "stealthy-require": "^1.1.0",
+        "tough-cookie": ">=2.3.3"
       }
     },
     "require-directory": {
@@ -4202,7 +4758,7 @@
       "integrity": "sha1-AKn3OHVW4nA46uIyyqNypqWbZlo=",
       "dev": true,
       "requires": {
-        "resolve-from": "3.0.0"
+        "resolve-from": "^3.0.0"
       }
     },
     "resolve-from": {
@@ -4223,7 +4779,7 @@
       "integrity": "sha1-kYcg7ztjHFZCvgaPFa3lpG9Loec=",
       "dev": true,
       "requires": {
-        "lowercase-keys": "1.0.1"
+        "lowercase-keys": "^1.0.0"
       }
     },
     "ret": {
@@ -4239,7 +4795,7 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "align-text": "0.1.4"
+        "align-text": "^0.1.1"
       }
     },
     "rimraf": {
@@ -4248,7 +4804,7 @@
       "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
       "dev": true,
       "requires": {
-        "glob": "7.1.2"
+        "glob": "^7.0.5"
       }
     },
     "rsvp": {
@@ -4269,7 +4825,7 @@
       "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
       "dev": true,
       "requires": {
-        "ret": "0.1.15"
+        "ret": "~0.1.10"
       }
     },
     "safer-buffer": {
@@ -4284,14 +4840,15 @@
       "integrity": "sha1-tNwYYcIbQn6SlQej51HiosuKs/o=",
       "dev": true,
       "requires": {
-        "anymatch": "2.0.0",
-        "capture-exit": "1.2.0",
-        "exec-sh": "0.2.1",
-        "fb-watchman": "2.0.0",
-        "micromatch": "3.1.10",
-        "minimist": "1.2.0",
-        "walker": "1.0.7",
-        "watch": "0.18.0"
+        "anymatch": "^2.0.0",
+        "capture-exit": "^1.2.0",
+        "exec-sh": "^0.2.0",
+        "fb-watchman": "^2.0.0",
+        "fsevents": "^1.2.3",
+        "micromatch": "^3.1.4",
+        "minimist": "^1.1.1",
+        "walker": "~1.0.5",
+        "watch": "~0.18.0"
       },
       "dependencies": {
         "kind-of": {
@@ -4306,19 +4863,19 @@
           "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
           "dev": true,
           "requires": {
-            "arr-diff": "4.0.0",
-            "array-unique": "0.3.2",
-            "braces": "2.3.2",
-            "define-property": "2.0.2",
-            "extend-shallow": "3.0.2",
-            "extglob": "2.0.4",
-            "fragment-cache": "0.2.1",
-            "kind-of": "6.0.2",
-            "nanomatch": "1.2.9",
-            "object.pick": "1.3.0",
-            "regex-not": "1.0.2",
-            "snapdragon": "0.8.2",
-            "to-regex": "3.0.2"
+            "arr-diff": "^4.0.0",
+            "array-unique": "^0.3.2",
+            "braces": "^2.3.1",
+            "define-property": "^2.0.2",
+            "extend-shallow": "^3.0.2",
+            "extglob": "^2.0.4",
+            "fragment-cache": "^0.2.1",
+            "kind-of": "^6.0.2",
+            "nanomatch": "^1.2.9",
+            "object.pick": "^1.3.0",
+            "regex-not": "^1.0.0",
+            "snapdragon": "^0.8.1",
+            "to-regex": "^3.0.2"
           }
         },
         "minimist": {
@@ -4341,7 +4898,7 @@
       "integrity": "sha1-z+kXyz0nS8/6x5J1ivUxc+sfq9w=",
       "dev": true,
       "requires": {
-        "commander": "2.8.1"
+        "commander": "~2.8.1"
       }
     },
     "semver": {
@@ -4362,10 +4919,10 @@
       "integrity": "sha512-hw0yxk9GT/Hr5yJEYnHNKYXkIA8mVJgd9ditYZCe16ZczcaELYYcfvaXesNACk2O8O0nTiPQcQhGUQj8JLzeeg==",
       "dev": true,
       "requires": {
-        "extend-shallow": "2.0.1",
-        "is-extendable": "0.1.1",
-        "is-plain-object": "2.0.4",
-        "split-string": "3.1.0"
+        "extend-shallow": "^2.0.1",
+        "is-extendable": "^0.1.1",
+        "is-plain-object": "^2.0.3",
+        "split-string": "^3.0.1"
       },
       "dependencies": {
         "extend-shallow": {
@@ -4374,7 +4931,7 @@
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "dev": true,
           "requires": {
-            "is-extendable": "0.1.1"
+            "is-extendable": "^0.1.0"
           }
         }
       }
@@ -4385,7 +4942,7 @@
       "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
       "dev": true,
       "requires": {
-        "shebang-regex": "1.0.0"
+        "shebang-regex": "^1.0.0"
       }
     },
     "shebang-regex": {
@@ -4418,14 +4975,14 @@
       "integrity": "sha512-FtyOnWN/wCHTVXOMwvSv26d+ko5vWlIDD6zoUJ7LW8vh+ZBC8QdljveRP+crNrtBwioEUWy/4dMtbBjA4ioNlg==",
       "dev": true,
       "requires": {
-        "base": "0.11.2",
-        "debug": "2.6.9",
-        "define-property": "0.2.5",
-        "extend-shallow": "2.0.1",
-        "map-cache": "0.2.2",
-        "source-map": "0.5.7",
-        "source-map-resolve": "0.5.2",
-        "use": "3.1.0"
+        "base": "^0.11.1",
+        "debug": "^2.2.0",
+        "define-property": "^0.2.5",
+        "extend-shallow": "^2.0.1",
+        "map-cache": "^0.2.2",
+        "source-map": "^0.5.6",
+        "source-map-resolve": "^0.5.0",
+        "use": "^3.1.0"
       },
       "dependencies": {
         "define-property": {
@@ -4434,7 +4991,7 @@
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "dev": true,
           "requires": {
-            "is-descriptor": "0.1.6"
+            "is-descriptor": "^0.1.0"
           }
         },
         "extend-shallow": {
@@ -4443,7 +5000,7 @@
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "dev": true,
           "requires": {
-            "is-extendable": "0.1.1"
+            "is-extendable": "^0.1.0"
           }
         }
       }
@@ -4454,9 +5011,9 @@
       "integrity": "sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==",
       "dev": true,
       "requires": {
-        "define-property": "1.0.0",
-        "isobject": "3.0.1",
-        "snapdragon-util": "3.0.1"
+        "define-property": "^1.0.0",
+        "isobject": "^3.0.0",
+        "snapdragon-util": "^3.0.1"
       },
       "dependencies": {
         "define-property": {
@@ -4465,7 +5022,7 @@
           "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
           "dev": true,
           "requires": {
-            "is-descriptor": "1.0.2"
+            "is-descriptor": "^1.0.0"
           }
         },
         "is-accessor-descriptor": {
@@ -4474,7 +5031,7 @@
           "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
           "dev": true,
           "requires": {
-            "kind-of": "6.0.2"
+            "kind-of": "^6.0.0"
           }
         },
         "is-data-descriptor": {
@@ -4483,7 +5040,7 @@
           "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
           "dev": true,
           "requires": {
-            "kind-of": "6.0.2"
+            "kind-of": "^6.0.0"
           }
         },
         "is-descriptor": {
@@ -4492,9 +5049,9 @@
           "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
           "dev": true,
           "requires": {
-            "is-accessor-descriptor": "1.0.0",
-            "is-data-descriptor": "1.0.0",
-            "kind-of": "6.0.2"
+            "is-accessor-descriptor": "^1.0.0",
+            "is-data-descriptor": "^1.0.0",
+            "kind-of": "^6.0.2"
           }
         },
         "kind-of": {
@@ -4511,7 +5068,7 @@
       "integrity": "sha512-mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ==",
       "dev": true,
       "requires": {
-        "kind-of": "3.2.2"
+        "kind-of": "^3.2.0"
       }
     },
     "sort-keys": {
@@ -4520,7 +5077,7 @@
       "integrity": "sha1-RBttTTRnmPG05J6JIK37oOVD+a0=",
       "dev": true,
       "requires": {
-        "is-plain-obj": "1.1.0"
+        "is-plain-obj": "^1.0.0"
       }
     },
     "sort-keys-length": {
@@ -4529,7 +5086,7 @@
       "integrity": "sha1-nLb09OnkgVWmqgZx7dM2/xR5oYg=",
       "dev": true,
       "requires": {
-        "sort-keys": "1.1.2"
+        "sort-keys": "^1.0.0"
       }
     },
     "source-map": {
@@ -4544,11 +5101,11 @@
       "integrity": "sha512-MjqsvNwyz1s0k81Goz/9vRBe9SZdB09Bdw+/zYyO+3CuPk6fouTaxscHkgtE8jKvf01kVfl8riHzERQ/kefaSA==",
       "dev": true,
       "requires": {
-        "atob": "2.1.1",
-        "decode-uri-component": "0.2.0",
-        "resolve-url": "0.2.1",
-        "source-map-url": "0.4.0",
-        "urix": "0.1.0"
+        "atob": "^2.1.1",
+        "decode-uri-component": "^0.2.0",
+        "resolve-url": "^0.2.1",
+        "source-map-url": "^0.4.0",
+        "urix": "^0.1.0"
       }
     },
     "source-map-support": {
@@ -4557,7 +5114,7 @@
       "integrity": "sha512-try0/JqxPLF9nOjvSta7tVondkP5dwgyLDjVoyMDlmjugT2lRZ1OfsrYTkCd2hkDnJTKRbO/Rl3orm8vlsUzbA==",
       "dev": true,
       "requires": {
-        "source-map": "0.5.7"
+        "source-map": "^0.5.6"
       }
     },
     "source-map-url": {
@@ -4572,8 +5129,8 @@
       "integrity": "sha512-N19o9z5cEyc8yQQPukRCZ9EUmb4HUpnrmaL/fxS2pBo2jbfcFRVuFZ/oFC+vZz0MNNk0h80iMn5/S6qGZOL5+g==",
       "dev": true,
       "requires": {
-        "spdx-expression-parse": "3.0.0",
-        "spdx-license-ids": "3.0.0"
+        "spdx-expression-parse": "^3.0.0",
+        "spdx-license-ids": "^3.0.0"
       }
     },
     "spdx-exceptions": {
@@ -4588,8 +5145,8 @@
       "integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
       "dev": true,
       "requires": {
-        "spdx-exceptions": "2.1.0",
-        "spdx-license-ids": "3.0.0"
+        "spdx-exceptions": "^2.1.0",
+        "spdx-license-ids": "^3.0.0"
       }
     },
     "spdx-license-ids": {
@@ -4604,7 +5161,7 @@
       "integrity": "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==",
       "dev": true,
       "requires": {
-        "extend-shallow": "3.0.2"
+        "extend-shallow": "^3.0.0"
       }
     },
     "sprintf-js": {
@@ -4619,15 +5176,15 @@
       "integrity": "sha1-xvxhZIo9nE52T9P8306hBeSSupg=",
       "dev": true,
       "requires": {
-        "asn1": "0.2.3",
-        "assert-plus": "1.0.0",
-        "bcrypt-pbkdf": "1.0.1",
-        "dashdash": "1.14.1",
-        "ecc-jsbn": "0.1.1",
-        "getpass": "0.1.7",
-        "jsbn": "0.1.1",
-        "safer-buffer": "2.1.2",
-        "tweetnacl": "0.14.5"
+        "asn1": "~0.2.3",
+        "assert-plus": "^1.0.0",
+        "bcrypt-pbkdf": "^1.0.0",
+        "dashdash": "^1.12.0",
+        "ecc-jsbn": "~0.1.1",
+        "getpass": "^0.1.1",
+        "jsbn": "~0.1.0",
+        "safer-buffer": "^2.0.2",
+        "tweetnacl": "~0.14.0"
       }
     },
     "stack-utils": {
@@ -4642,8 +5199,8 @@
       "integrity": "sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=",
       "dev": true,
       "requires": {
-        "define-property": "0.2.5",
-        "object-copy": "0.1.0"
+        "define-property": "^0.2.5",
+        "object-copy": "^0.1.0"
       },
       "dependencies": {
         "define-property": {
@@ -4652,7 +5209,7 @@
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "dev": true,
           "requires": {
-            "is-descriptor": "0.1.6"
+            "is-descriptor": "^0.1.0"
           }
         }
       }
@@ -4675,8 +5232,8 @@
       "integrity": "sha1-1A27aGo6zpYMHP/KVivyxF+DY+0=",
       "dev": true,
       "requires": {
-        "astral-regex": "1.0.0",
-        "strip-ansi": "4.0.0"
+        "astral-regex": "^1.0.0",
+        "strip-ansi": "^4.0.0"
       }
     },
     "string-width": {
@@ -4685,8 +5242,8 @@
       "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
       "dev": true,
       "requires": {
-        "is-fullwidth-code-point": "2.0.0",
-        "strip-ansi": "4.0.0"
+        "is-fullwidth-code-point": "^2.0.0",
+        "strip-ansi": "^4.0.0"
       }
     },
     "string_decoder": {
@@ -4695,7 +5252,7 @@
       "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
       "dev": true,
       "requires": {
-        "safe-buffer": "5.1.2"
+        "safe-buffer": "~5.1.0"
       }
     },
     "strip-ansi": {
@@ -4704,7 +5261,7 @@
       "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
       "dev": true,
       "requires": {
-        "ansi-regex": "3.0.0"
+        "ansi-regex": "^3.0.0"
       },
       "dependencies": {
         "ansi-regex": {
@@ -4727,7 +5284,7 @@
       "integrity": "sha512-JOCxOeKLm2CAS73y/U4ZeZPTkE+gNVCzKt7Eox84Iej1LT/2pTWYpZKJuxwQpvX1LiZb1xokNR7RLfuBAa7T3g==",
       "dev": true,
       "requires": {
-        "is-natural-number": "4.0.1"
+        "is-natural-number": "^4.0.1"
       }
     },
     "strip-eof": {
@@ -4742,7 +5299,7 @@
       "integrity": "sha512-k55yxKHwaXnpYGsOzg4Vl8+tDrWylxDEpknGjhTiZB8dFRU5rTo9CAzeycivxV3s+zlTKwrs6WxMxR95n26kwg==",
       "dev": true,
       "requires": {
-        "escape-string-regexp": "1.0.5"
+        "escape-string-regexp": "^1.0.2"
       }
     },
     "supports-color": {
@@ -4751,7 +5308,7 @@
       "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
       "dev": true,
       "requires": {
-        "has-flag": "3.0.0"
+        "has-flag": "^3.0.0"
       }
     },
     "symbol-tree": {
@@ -4766,13 +5323,13 @@
       "integrity": "sha512-IFLM5wp3QrJODQFPm6/to3LJZrONdBY/otxcvDIQzu217zKye6yVR3hhi9lAjrC2Z+m/j5oDxMPb1qcd8cIvpA==",
       "dev": true,
       "requires": {
-        "bl": "1.2.2",
-        "buffer-alloc": "1.2.0",
-        "end-of-stream": "1.4.1",
-        "fs-constants": "1.0.0",
-        "readable-stream": "2.3.6",
-        "to-buffer": "1.1.1",
-        "xtend": "4.0.1"
+        "bl": "^1.0.0",
+        "buffer-alloc": "^1.1.0",
+        "end-of-stream": "^1.0.0",
+        "fs-constants": "^1.0.0",
+        "readable-stream": "^2.3.0",
+        "to-buffer": "^1.1.0",
+        "xtend": "^4.0.0"
       }
     },
     "test-exclude": {
@@ -4781,11 +5338,11 @@
       "integrity": "sha512-qpqlP/8Zl+sosLxBcVKl9vYy26T9NPalxSzzCP/OY6K7j938ui2oKgo+kRZYfxAeIpLqpbVnsHq1tyV70E4lWQ==",
       "dev": true,
       "requires": {
-        "arrify": "1.0.1",
-        "micromatch": "3.1.10",
-        "object-assign": "4.1.1",
-        "read-pkg-up": "1.0.1",
-        "require-main-filename": "1.0.1"
+        "arrify": "^1.0.1",
+        "micromatch": "^3.1.8",
+        "object-assign": "^4.1.0",
+        "read-pkg-up": "^1.0.1",
+        "require-main-filename": "^1.0.1"
       },
       "dependencies": {
         "kind-of": {
@@ -4800,19 +5357,19 @@
           "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
           "dev": true,
           "requires": {
-            "arr-diff": "4.0.0",
-            "array-unique": "0.3.2",
-            "braces": "2.3.2",
-            "define-property": "2.0.2",
-            "extend-shallow": "3.0.2",
-            "extglob": "2.0.4",
-            "fragment-cache": "0.2.1",
-            "kind-of": "6.0.2",
-            "nanomatch": "1.2.9",
-            "object.pick": "1.3.0",
-            "regex-not": "1.0.2",
-            "snapdragon": "0.8.2",
-            "to-regex": "3.0.2"
+            "arr-diff": "^4.0.0",
+            "array-unique": "^0.3.2",
+            "braces": "^2.3.1",
+            "define-property": "^2.0.2",
+            "extend-shallow": "^3.0.2",
+            "extglob": "^2.0.4",
+            "fragment-cache": "^0.2.1",
+            "kind-of": "^6.0.2",
+            "nanomatch": "^1.2.9",
+            "object.pick": "^1.3.0",
+            "regex-not": "^1.0.0",
+            "snapdragon": "^0.8.1",
+            "to-regex": "^3.0.2"
           }
         }
       }
@@ -4859,7 +5416,7 @@
       "integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
       "dev": true,
       "requires": {
-        "kind-of": "3.2.2"
+        "kind-of": "^3.0.2"
       }
     },
     "to-regex": {
@@ -4868,10 +5425,10 @@
       "integrity": "sha512-FWtleNAtZ/Ki2qtqej2CXTOayOH9bHDQF+Q48VpWyDXjbYxA4Yz8iDB31zXOBUlOHHKidDbqGVrTUvQMPmBGBw==",
       "dev": true,
       "requires": {
-        "define-property": "2.0.2",
-        "extend-shallow": "3.0.2",
-        "regex-not": "1.0.2",
-        "safe-regex": "1.1.0"
+        "define-property": "^2.0.2",
+        "extend-shallow": "^3.0.2",
+        "regex-not": "^1.0.2",
+        "safe-regex": "^1.1.0"
       }
     },
     "to-regex-range": {
@@ -4880,8 +5437,8 @@
       "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
       "dev": true,
       "requires": {
-        "is-number": "3.0.0",
-        "repeat-string": "1.6.1"
+        "is-number": "^3.0.0",
+        "repeat-string": "^1.6.1"
       }
     },
     "tough-cookie": {
@@ -4890,8 +5447,8 @@
       "integrity": "sha512-vahm+X8lSV/KjXziec8x5Vp0OTC9mq8EVCOApIsRAooeuMPSO8aT7PFACYkaL0yZ/3hVqw+8DzhCJwl8H2Ad6w==",
       "dev": true,
       "requires": {
-        "psl": "1.1.28",
-        "punycode": "1.4.1"
+        "psl": "^1.1.24",
+        "punycode": "^1.4.1"
       },
       "dependencies": {
         "punycode": {
@@ -4908,7 +5465,7 @@
       "integrity": "sha1-qLE/1r/SSJUZZ0zN5VujaTtwbQk=",
       "dev": true,
       "requires": {
-        "punycode": "2.1.1"
+        "punycode": "^2.1.0"
       }
     },
     "trim-repeated": {
@@ -4917,7 +5474,7 @@
       "integrity": "sha1-42RqLqTokTEr9+rObPsFOAvAHCE=",
       "dev": true,
       "requires": {
-        "escape-string-regexp": "1.0.5"
+        "escape-string-regexp": "^1.0.2"
       }
     },
     "trim-right": {
@@ -4932,7 +5489,7 @@
       "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
       "dev": true,
       "requires": {
-        "safe-buffer": "5.1.2"
+        "safe-buffer": "^5.0.1"
       }
     },
     "tweetnacl": {
@@ -4948,7 +5505,7 @@
       "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
       "dev": true,
       "requires": {
-        "prelude-ls": "1.1.2"
+        "prelude-ls": "~1.1.2"
       }
     },
     "uglify-js": {
@@ -4958,9 +5515,9 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "source-map": "0.5.7",
-        "uglify-to-browserify": "1.0.2",
-        "yargs": "3.10.0"
+        "source-map": "~0.5.1",
+        "uglify-to-browserify": "~1.0.0",
+        "yargs": "~3.10.0"
       },
       "dependencies": {
         "yargs": {
@@ -4970,9 +5527,9 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "camelcase": "1.2.1",
-            "cliui": "2.1.0",
-            "decamelize": "1.2.0",
+            "camelcase": "^1.0.2",
+            "cliui": "^2.1.0",
+            "decamelize": "^1.0.0",
             "window-size": "0.1.0"
           }
         }
@@ -4991,8 +5548,8 @@
       "integrity": "sha512-izD3jxT8xkzwtXRUZjtmRwKnZoeECrfZ8ra/ketwOcusbZEp4mjULMnJOCfTDZBgGQAAY1AJ/IgxcwkavcX9Og==",
       "dev": true,
       "requires": {
-        "buffer": "3.6.0",
-        "through": "2.3.8"
+        "buffer": "^3.0.1",
+        "through": "^2.3.6"
       }
     },
     "union-value": {
@@ -5001,10 +5558,10 @@
       "integrity": "sha1-XHHDTLW61dzr4+oM0IIHulqhrqQ=",
       "dev": true,
       "requires": {
-        "arr-union": "3.1.0",
-        "get-value": "2.0.6",
-        "is-extendable": "0.1.1",
-        "set-value": "0.4.3"
+        "arr-union": "^3.1.0",
+        "get-value": "^2.0.6",
+        "is-extendable": "^0.1.1",
+        "set-value": "^0.4.3"
       },
       "dependencies": {
         "extend-shallow": {
@@ -5013,7 +5570,7 @@
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "dev": true,
           "requires": {
-            "is-extendable": "0.1.1"
+            "is-extendable": "^0.1.0"
           }
         },
         "set-value": {
@@ -5022,13 +5579,19 @@
           "integrity": "sha1-fbCPnT0i3H945Trzw79GZuzfzPE=",
           "dev": true,
           "requires": {
-            "extend-shallow": "2.0.1",
-            "is-extendable": "0.1.1",
-            "is-plain-object": "2.0.4",
-            "to-object-path": "0.3.0"
+            "extend-shallow": "^2.0.1",
+            "is-extendable": "^0.1.1",
+            "is-plain-object": "^2.0.1",
+            "to-object-path": "^0.3.0"
           }
         }
       }
+    },
+    "universalify": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
+      "dev": true
     },
     "unset-value": {
       "version": "1.0.0",
@@ -5036,8 +5599,8 @@
       "integrity": "sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=",
       "dev": true,
       "requires": {
-        "has-value": "0.3.1",
-        "isobject": "3.0.1"
+        "has-value": "^0.3.1",
+        "isobject": "^3.0.0"
       },
       "dependencies": {
         "has-value": {
@@ -5046,9 +5609,9 @@
           "integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
           "dev": true,
           "requires": {
-            "get-value": "2.0.6",
-            "has-values": "0.1.4",
-            "isobject": "2.1.0"
+            "get-value": "^2.0.3",
+            "has-values": "^0.1.4",
+            "isobject": "^2.0.0"
           },
           "dependencies": {
             "isobject": {
@@ -5082,7 +5645,7 @@
       "integrity": "sha1-FrXK/Afb42dsGxmZF3gj1lA6yww=",
       "dev": true,
       "requires": {
-        "prepend-http": "2.0.0"
+        "prepend-http": "^2.0.0"
       }
     },
     "url-to-options": {
@@ -5097,7 +5660,7 @@
       "integrity": "sha512-6UJEQM/L+mzC3ZJNM56Q4DFGLX/evKGRg15UJHGB9X5j5Z3AFbgZvjUh2yq/UJUY4U5dh7Fal++XbNg1uzpRAw==",
       "dev": true,
       "requires": {
-        "kind-of": "6.0.2"
+        "kind-of": "^6.0.2"
       },
       "dependencies": {
         "kind-of": {
@@ -5120,8 +5683,8 @@
       "integrity": "sha512-i+6qA2MPhvoKLuxnJNpXAGhg7HphQOSUq2LKMZD0m15EiskXUkMvKdF4Uui0WYeCUGea+o2cw/ZuwehtfsrNkA==",
       "dev": true,
       "requires": {
-        "define-properties": "1.1.2",
-        "object.getownpropertydescriptors": "2.0.3"
+        "define-properties": "^1.1.2",
+        "object.getownpropertydescriptors": "^2.0.3"
       }
     },
     "uuid": {
@@ -5136,8 +5699,8 @@
       "integrity": "sha512-63ZOUnL4SIXj4L0NixR3L1lcjO38crAbgrTpl28t8jjrfuiOBL5Iygm+60qPs/KsZGzPNg6Smnc/oY16QTjF0g==",
       "dev": true,
       "requires": {
-        "spdx-correct": "3.0.0",
-        "spdx-expression-parse": "3.0.0"
+        "spdx-correct": "^3.0.0",
+        "spdx-expression-parse": "^3.0.0"
       }
     },
     "verror": {
@@ -5146,9 +5709,9 @@
       "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
       "dev": true,
       "requires": {
-        "assert-plus": "1.0.0",
+        "assert-plus": "^1.0.0",
         "core-util-is": "1.0.2",
-        "extsprintf": "1.3.0"
+        "extsprintf": "^1.2.0"
       }
     },
     "w3c-hr-time": {
@@ -5157,7 +5720,7 @@
       "integrity": "sha1-gqwr/2PZUOqeMYmlimViX+3xkEU=",
       "dev": true,
       "requires": {
-        "browser-process-hrtime": "0.1.2"
+        "browser-process-hrtime": "^0.1.2"
       }
     },
     "walker": {
@@ -5166,7 +5729,7 @@
       "integrity": "sha1-L3+bj9ENZ3JisYqITijRlhjgKPs=",
       "dev": true,
       "requires": {
-        "makeerror": "1.0.11"
+        "makeerror": "1.0.x"
       }
     },
     "watch": {
@@ -5175,8 +5738,8 @@
       "integrity": "sha1-KAlUdsbffJDJYxOJkMClQj60uYY=",
       "dev": true,
       "requires": {
-        "exec-sh": "0.2.1",
-        "minimist": "1.2.0"
+        "exec-sh": "^0.2.0",
+        "minimist": "^1.2.0"
       },
       "dependencies": {
         "minimist": {
@@ -5214,9 +5777,9 @@
       "integrity": "sha512-rhRZRqx/TLJQWUpQ6bmrt2UV4f0HCQ463yQuONJqC6fO2VoEb1pTYddbe59SkYq87aoM5A3bdhMZiUiVws+fzQ==",
       "dev": true,
       "requires": {
-        "lodash.sortby": "4.7.0",
-        "tr46": "1.0.1",
-        "webidl-conversions": "4.0.2"
+        "lodash.sortby": "^4.7.0",
+        "tr46": "^1.0.1",
+        "webidl-conversions": "^4.0.2"
       }
     },
     "which": {
@@ -5225,7 +5788,7 @@
       "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
       "dev": true,
       "requires": {
-        "isexe": "2.0.0"
+        "isexe": "^2.0.0"
       }
     },
     "which-module": {
@@ -5253,8 +5816,8 @@
       "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
       "dev": true,
       "requires": {
-        "string-width": "1.0.2",
-        "strip-ansi": "3.0.1"
+        "string-width": "^1.0.1",
+        "strip-ansi": "^3.0.1"
       },
       "dependencies": {
         "is-fullwidth-code-point": {
@@ -5263,7 +5826,7 @@
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "dev": true,
           "requires": {
-            "number-is-nan": "1.0.1"
+            "number-is-nan": "^1.0.0"
           }
         },
         "string-width": {
@@ -5272,9 +5835,9 @@
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "dev": true,
           "requires": {
-            "code-point-at": "1.1.0",
-            "is-fullwidth-code-point": "1.0.0",
-            "strip-ansi": "3.0.1"
+            "code-point-at": "^1.0.0",
+            "is-fullwidth-code-point": "^1.0.0",
+            "strip-ansi": "^3.0.0"
           }
         },
         "strip-ansi": {
@@ -5283,7 +5846,7 @@
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
           "requires": {
-            "ansi-regex": "2.1.1"
+            "ansi-regex": "^2.0.0"
           }
         }
       }
@@ -5300,9 +5863,9 @@
       "integrity": "sha512-xuPeK4OdjWqtfi59ylvVL0Yn35SF3zgcAcv7rBPFHVaEapaDr4GdGgm3j7ckTwH9wHL7fGmgfAnb0+THrHb8tA==",
       "dev": true,
       "requires": {
-        "graceful-fs": "4.1.11",
-        "imurmurhash": "0.1.4",
-        "signal-exit": "3.0.2"
+        "graceful-fs": "^4.1.11",
+        "imurmurhash": "^0.1.4",
+        "signal-exit": "^3.0.2"
       }
     },
     "ws": {
@@ -5311,8 +5874,8 @@
       "integrity": "sha512-ZGh/8kF9rrRNffkLFV4AzhvooEclrOH0xaugmqGsIfFgOE/pIz4fMc4Ef+5HSQqTEug2S9JZIWDR47duDSLfaA==",
       "dev": true,
       "requires": {
-        "async-limiter": "1.0.0",
-        "safe-buffer": "5.1.2"
+        "async-limiter": "~1.0.0",
+        "safe-buffer": "~5.1.0"
       }
     },
     "xml-name-validator": {
@@ -5345,18 +5908,18 @@
       "integrity": "sha512-Rjp+lMYQOWtgqojx1dEWorjCofi1YN7AoFvYV7b1gx/7dAAeuI4kN5SZiEvr0ZmsZTOpDRcCqrpI10L31tFkBw==",
       "dev": true,
       "requires": {
-        "cliui": "4.1.0",
-        "decamelize": "1.2.0",
-        "find-up": "2.1.0",
-        "get-caller-file": "1.0.2",
-        "os-locale": "2.1.0",
-        "require-directory": "2.1.1",
-        "require-main-filename": "1.0.1",
-        "set-blocking": "2.0.0",
-        "string-width": "2.1.1",
-        "which-module": "2.0.0",
-        "y18n": "3.2.1",
-        "yargs-parser": "9.0.2"
+        "cliui": "^4.0.0",
+        "decamelize": "^1.1.1",
+        "find-up": "^2.1.0",
+        "get-caller-file": "^1.0.1",
+        "os-locale": "^2.0.0",
+        "require-directory": "^2.1.1",
+        "require-main-filename": "^1.0.1",
+        "set-blocking": "^2.0.0",
+        "string-width": "^2.0.0",
+        "which-module": "^2.0.0",
+        "y18n": "^3.2.1",
+        "yargs-parser": "^9.0.2"
       },
       "dependencies": {
         "cliui": {
@@ -5365,9 +5928,9 @@
           "integrity": "sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==",
           "dev": true,
           "requires": {
-            "string-width": "2.1.1",
-            "strip-ansi": "4.0.0",
-            "wrap-ansi": "2.1.0"
+            "string-width": "^2.1.1",
+            "strip-ansi": "^4.0.0",
+            "wrap-ansi": "^2.0.0"
           }
         }
       }
@@ -5378,7 +5941,7 @@
       "integrity": "sha1-nM9qQ0YP5O1Aqbto9I1DuKaMwHc=",
       "dev": true,
       "requires": {
-        "camelcase": "4.1.0"
+        "camelcase": "^4.1.0"
       },
       "dependencies": {
         "camelcase": {
@@ -5395,8 +5958,8 @@
       "integrity": "sha1-T7G8euH8L1cDe1SvasyP4QMcW3c=",
       "dev": true,
       "requires": {
-        "buffer-crc32": "0.2.13",
-        "fd-slicer": "1.1.0"
+        "buffer-crc32": "~0.2.3",
+        "fd-slicer": "~1.1.0"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "esy-bash-test",
-  "version": "0.0.101",
+  "name": "esy-bash",
+  "version": "0.1.24",
   "description": "Cross-platform bash utilities - primed for Reason/OCaml",
   "main": "index.js",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "esy-bash",
+  "name": "esy-bash-test",
   "version": "0.1.24",
   "description": "Cross-platform bash utilities - primed for Reason/OCaml",
   "main": "index.js",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,10 @@
     "node": ">=8.0"
   },
   "files": [
-    ".cygwin"
+    ".cygwin",
+    "re/_build/default",
+    "bash-exec.js",
+    "bin/esy-bash.js"
   ],
   "scripts": {
     "build-cygwin": "node build-cygwin.js",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     ".cygwin"
   ],
   "scripts": {
-    "build": "node build.js",
+    "build-cygwin": "node build-cygwin.js",
     "test": "jest",
     "postinstall": "node postinstall.js"
   },

--- a/package.json
+++ b/package.json
@@ -14,8 +14,7 @@
   ],
   "scripts": {
     "build-cygwin": "node build-cygwin.js",
-    "test": "jest",
-    "postinstall": "node postinstall.js"
+    "test": "jest"
   },
   "repository": {
     "type": "git",
@@ -27,11 +26,11 @@
     "url": "https://github.com/bryphe/esy-cygwin/issues"
   },
   "homepage": "https://github.com/bryphe/esy-cygwin#readme",
-  "dependencies": {
+  "dependencies": {},
+  "devDependencies": {
+    "jest": "^23.1.0",
+    "rimraf": "^2.6.2",
     "download": "^7.0.0",
     "mkdirp": "^0.5.1"
-  },
-  "devDependencies": {
-    "jest": "^23.1.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -9,7 +9,11 @@
   "engines": {
     "node": ">=8.0"
   },
+  "files": [
+    ".cygwin"
+  ],
   "scripts": {
+    "build": "node build.js",
     "test": "jest",
     "postinstall": "node postinstall.js"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "esy-bash-test",
-  "version": "0.1.24",
+  "version": "0.0.100",
   "description": "Cross-platform bash utilities - primed for Reason/OCaml",
   "main": "index.js",
   "bin": {
@@ -31,9 +31,9 @@
   "homepage": "https://github.com/bryphe/esy-cygwin#readme",
   "dependencies": {},
   "devDependencies": {
-    "jest": "^23.1.0",
-    "rimraf": "^2.6.2",
     "download": "^7.0.0",
-    "mkdirp": "^0.5.1"
+    "jest": "^23.1.0",
+    "mkdirp": "^0.5.1",
+    "rimraf": "^2.6.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "esy-bash-test",
-  "version": "0.0.100",
+  "version": "0.0.101",
   "description": "Cross-platform bash utilities - primed for Reason/OCaml",
   "main": "index.js",
   "bin": {
@@ -11,7 +11,7 @@
   },
   "files": [
     ".cygwin",
-    "re/_build/default",
+    "re/_build/default/bin/EsyBash.exe",
     "bash-exec.js",
     "bin/esy-bash.js"
   ],
@@ -32,6 +32,7 @@
   "dependencies": {},
   "devDependencies": {
     "download": "^7.0.0",
+    "fs-extra": "^7.0.0",
     "jest": "^23.1.0",
     "mkdirp": "^0.5.1",
     "rimraf": "^2.6.2"


### PR DESCRIPTION
This addresses #12 and #13 - we're taking a snapshot of Cygwin at _build_ time, and including the `.cygwin` folder as part of our NPM package.

The NPM package ends up being ~120MB, but low on dependencies - and installs _much_ faster than the equivalent operation via the cygwin installer.

A few changes that were needed:
- Explicitly call out folders / files to include in `package.json`
- Set the `NODE_OPTIONS` to use a larger heap size, otherwise the publish step fails with an out-of-memory error.
- Delete items in the `/var/cache` folder, as cached packages are kept there, and we don't need those once they are unpacked - they'd just weigh the package down.