### PR TITLE
Run rebase steps on postinstall

### DIFF
--- a/postinstall.js
+++ b/postinstall.js
@@ -1,21 +1,51 @@
-
 if (process.platform !== "win32") {
     console.log("No unpack needed");
     return 0;
 }
 
+const cp = require("child_process");
 const fs = require("fs");
 const path = require("path");
 const { restoreLinks } = require("./scripts/consolidate-links");
+
+const cygwinPath = path.join(__dirname, ".cygwin");
+const cygwinBinPath = path.join(__dirname, ".cygwin", "bin");
 
 if (!fs.existsSync(path.join(__dirname, ".cygwin"))) {
     console.warn("No cygwin folder found, not restoring links");
     return 0;
 }
 
+let runPostCommand = (command, args, opts) => {
+    opts = opts || {};
+    let ret = cp.spawnSync(command, args, opts);
+
+    if (ret.error) {
+        throw(ret.error);
+    } else if (ret.status !== 0) {
+        console.error("[ERROR] stdout: " + ret.stdout.toString("utf8") + "\nstderr: " + ret.stderr.toString("utf8") + "\n");
+        throw("Operation failed: " + command);
+    }
+};
+
 let restore = async () => {
     console.log("Restoring hardlinks...");
     await restoreLinks();
+
+    // Without rebasing, we'll hit errors like:
+    // [main] make 10588 child_info_fork::abort: <some path>cygwin\bin\cygiconv-2.dll: Loaded to different address: parent(0x3FF530000) != child(0xDF0000)
+    // Usually, the cygwin setup.exe takes care of setting up the dll rebasing - but since we're not running it on the host,
+    // we need to force a rebase.
+
+    console.log("Starting dll rebase...");
+    runPostCommand(path.join(cygwinBinPath, "bash.exe"), ["-lc", "/usr/bin/rebase-trigger fullrebase"]);
+    runPostCommand(path.join(cygwinBinPath, "dash.exe"), ["/etc/postinstall/0p_000_autorebase.dash"]);
+    runPostCommand(path.join(cygwinBinPath, "dash.exe"), ["/etc/postinstall/0p_update-info-dir.dash"], {
+        env: {
+            PATH: "/usr/bin"
+        }
+    });
+    console.log("Rebase complete.");
     console.log("Complete!");
 };
 


### PR DESCRIPTION
__Issue:__ We're seeing fork errors in Cygwin when running nightly builds. I haven't seen this occur in the 0.3.4 build. The errors are of the form:
```
      3 [main] make 10588 child_info_fork::abort: C:\Users\bryph\AppData\Roaming\npm\node_modules\@esy-nightly\esy\node_modules\esy-bash\.cygwin\bin\cygiconv-2.dll: Loaded to different address: parent(0x3FF530000) != child(0xDF0000)
```

@jordwalke made a good suggestion that that there might be a dll rebase issue here, and we need to run rebase on the install machine.

This would make sense, because on the nightly build, we are now using `esy-bash` builds that don't run the installer - we package cygwin in its entirety. However, one of the crucial steps the installer does is set up the rebase map / info.

The rebase info seems to be stored in `rebase.db.x86_64`, which we had been packing up. This should definitely be regenerated.

This attempts to run a full rebase along with the dash script used by the installer to set that info up.

Some additional info:
- https://cygwin.com/faq/faq.html
- http://cygwin.wikia.com/wiki/Rebaseall
- https://stackoverflow.com/questions/37602608/cygwin-error-child-info-forkabort-loaded-to-different-address