### PR TITLE
Bugfix: "Unhandled rejection" error

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "esy-bash",
-  "version": "0.3.13",
+  "version": "0.3.14",
   "description": "Cross-platform bash utilities - primed for Reason/OCaml",
   "main": "index.js",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "esy-bash",
-  "version": "0.3.12",
+  "version": "0.3.13",
   "description": "Cross-platform bash utilities - primed for Reason/OCaml",
   "main": "index.js",
   "bin": {

--- a/scripts/consolidate-links.js
+++ b/scripts/consolidate-links.js
@@ -105,6 +105,13 @@ const ensureFolder = async (p) => {
     }
 
     await ensureFolder(path.dirname(p));
+
+    // There is a race condition here - double-check
+    // that the folder hasn't actually been created
+    // before creating it.
+    if(fs.existsSync(p)) {
+        return;
+    }
     await mkdirAsync(p);
 };
 

--- a/scripts/consolidate-links.js
+++ b/scripts/consolidate-links.js
@@ -109,7 +109,7 @@ const ensureFolder = async (p) => {
     // There is a race condition here - double-check
     // that the folder hasn't actually been created
     // before creating it.
-    if(fs.existsSync(p)) {
+    if (fs.existsSync(p)) {
         return;
     }
     await mkdirAsync(p);

--- a/scripts/consolidate-links.js
+++ b/scripts/consolidate-links.js
@@ -112,7 +112,8 @@ const ensureFolder = async (p) => {
     if (fs.existsSync(p)) {
         return;
     }
-    await mkdirAsync(p);
+    console.log("creating directory: " + p);
+    fs.mkdirSync(p);
 };
 
 const checkUserFolder = async (p) => {


### PR DESCRIPTION
Even after the first fix in #42 , there was still an additional error.

This change adds the following:
- Additional logging available via the `ESY_BASH_DEBUG` environment variable
- More information when `spawnAsync` fails to start

While debugging - I realized that the symlink creation logic was busted. When we do this via `EsyBash.exe`, it creates native symlinks, which will break w/o administrator permissions. This is problematic, because these symlinks actually were cygwin-style symlinks, and should be rehydrated as such. To do this, we'll use `bash.exe` instead for that operation - and not set the `CYGWIN` environment variable.