### PR TITLE
Bugfix: Switch to use sync mkdir for now

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "esy-bash",
-  "version": "0.3.15",
+  "version": "0.3.16",
   "description": "Cross-platform bash utilities - primed for Reason/OCaml",
   "main": "index.js",
   "bin": {

--- a/scripts/consolidate-links.js
+++ b/scripts/consolidate-links.js
@@ -122,14 +122,14 @@ const ensureFolder = async (p) => {
 
     await ensureFolder(path.dirname(p));
 
-    // There is a race condition here - double-check
-    // that the folder hasn't actually been created
-    // before creating it.
+    // TODO: Don't use exists here.
+    // These are moved to sync now until we fix this codepath - 
+    // otherwise there is a race condition that hits an error.
     if (fs.existsSync(p)) {
         return;
+    } else {
+        fs.mkdirSync(p);
     }
-
-    await mkdirAsync(p);
 };
 
 const checkUserFolder = async (p) => {


### PR DESCRIPTION
We still hit the `EEXIST` race condition with the synchronous exists check:
```
unhandledRejection { [Error: EEXIST: file already exists, mkdir 'E:\test-esy-bash-3\node_modules\esy-bash\.cygwin\usr\x86_64-w64-mingw32\bin']
  errno: -4075,
  code: 'EEXIST',
  syscall: 'mkdir',
  path:
```

This moves to use `mkdirSync` to unblock (luckily, there are only a couple of folders that are created, so this has a low perf impact).

We should refactor this code to skip exists as suggested in #42 