### PR TITLE
Use single quotes for the path in the nested EsyBash call

### DIFF
--- a/scripts/consolidate-links.js
+++ b/scripts/consolidate-links.js
@@ -48,7 +48,7 @@ const spawnAsync = (command, args, options) => {
 
 const toCygwinPathAsync = async (p) => {
     p = p.split("\\").join("/")
-    let ret = await spawnAsync(path.join(rootFolder, "re", "_build", "default", "bin", "EsyBash.exe"), ["bash", "-lc", `cygpath "${p}"`]);
+    let ret = await spawnAsync(path.join(rootFolder, "re", "_build", "default", "bin", "EsyBash.exe"), ["bash", "-lc", `cygpath '${p}'`]);
     return ret.trim();
 }
 


### PR DESCRIPTION
Unfortunately, the previous PR didn't quite do the job yet on my machine. This one call where we invoke `bash` inside `EsyBash.exe` still caused trouble. It still didn't accept the path for some reason I don't quite understand.

The setup we have in this changed line of code is that we call bash within bash and the actual command is given as an argument.
For some reason, this causes trouble and the escaped quotes won't be accepted.

What I ended up with before were arguments like `"cygpath \"C:/Users/Manuel Hornung OSS/Downloads/esy-bash-0.3.18/package/.cygwin/bin/tic.exe\""` - note the escaped double quotes.
For some reason though, the way the `cygpath` command was interpreted dropped everything after `Manuel`, which makes me think that the escaped double quotes weren't correctly interpreted as such but rather dropped entirely.

By trial and error, I now found out that explicitly using escaped double quotes(`\"`) also doesn't do the trick while single quotes (`'`) work as expected.

So with the single quotes, the argument, which is in fact a command, turns out as  `"cygpath 'C:/Users/Manuel Hornung OSS/Downloads/esy-bash-0.3.18/package/.cygwin/bin/tic.exe'"` and the bash instance inside EsyBash seems to process it the right way.

Don't ask me why, I'm just hoping for CI to become green so I can finally update esy to the latest version of esy-bash and clone revery on my Windows machine :D